### PR TITLE
Implement Pokemon movement

### DIFF
--- a/src/objects/pokemon.object.ts
+++ b/src/objects/pokemon.object.ts
@@ -1,6 +1,6 @@
 import * as Phaser from 'phaser';
 import { Pokemon, pokemonData, PokemonName } from '../core/pokemon.model';
-import { Coords } from '../scenes/game/game.helpers';
+import { Coords, getTurnDelay } from '../scenes/game/game.helpers';
 import { FloatingText } from './floating-text.object';
 
 interface SpriteParams {
@@ -49,6 +49,19 @@ export class PokemonObject extends Phaser.GameObjects.Sprite {
 
     this.hpBar = this.scene.add.graphics();
     this.redrawHPBar();
+  }
+
+  setPosition(x: number, y: number) {
+    this.x = x;
+    this.y = y;
+    super.setPosition(x, y);
+    if (this.sprite) {
+      this.sprite.setPosition(x, y);
+    }
+    if (this.hpBar) {
+      this.hpBar.setPosition(x, y);
+    }
+    return this;
   }
 
   destroy() {
@@ -101,10 +114,16 @@ export class PokemonObject extends Phaser.GameObjects.Sprite {
   }
 
   public move({ x, y }: Coords) {
-    // TODO: play some animation / smooth movement
-    super.setPosition(x, y);
-    this.sprite.setPosition(x, y);
-    this.hpBar.setPosition(x, y);
+    this.scene.add.tween({
+      targets: [this.sprite, this.hpBar],
+      duration: getTurnDelay(this.basePokemon) * 0.75,
+      x,
+      y,
+      ease: 'Quad',
+      onComplete: () => {
+        this.setPosition(x, y);
+      },
+    });
   }
 
   public dealDamage(amount: number) {

--- a/src/objects/pokemon.object.ts
+++ b/src/objects/pokemon.object.ts
@@ -1,5 +1,6 @@
 import * as Phaser from 'phaser';
 import { Pokemon, pokemonData, PokemonName } from '../core/pokemon.model';
+import { Coords } from '../scenes/game/game.helpers';
 import { FloatingText } from './floating-text.object';
 
 interface SpriteParams {
@@ -95,8 +96,15 @@ export class PokemonObject extends Phaser.GameObjects.Sprite {
     return 0xdc143c;
   }
 
-  playAnimation(type: PokemonAnimationType) {
+  public playAnimation(type: PokemonAnimationType) {
     this.sprite.play(`${this.name}--${type}`);
+  }
+
+  public move({ x, y }: Coords) {
+    // TODO: play some animation / smooth movement
+    super.setPosition(x, y);
+    this.sprite.setPosition(x, y);
+    this.hpBar.setPosition(x, y);
   }
 
   public dealDamage(amount: number) {

--- a/src/scenes/game/game.helpers.spec.ts
+++ b/src/scenes/game/game.helpers.spec.ts
@@ -1,6 +1,6 @@
 import * as expect from 'expect';
 import { PokemonObject } from '../../objects/pokemon.object';
-import { getNearestTarget, pathfind } from './game.helpers';
+import { getFacing, getNearestTarget, pathfind } from './game.helpers';
 
 // TODO: Probably want to fix this, @typescript-eslint/no-object-literal-type-assertion
 const playerMock = { side: 'player' } as PokemonObject;
@@ -200,12 +200,11 @@ describe('getNearestTarget', () => {
   });
 });
 
-describe.only('pathfind', () => {
+describe('pathfind', () => {
   it(`should find a path between two points
     A>B
     ...
-    ...
-  `, () => {
+    ...`, () => {
     expect(
       pathfind(
         [[enemyMock], [], [playerMock]],
@@ -216,11 +215,10 @@ describe.only('pathfind', () => {
     ).toEqual({ x: 1, y: 0 });
   });
 
-  it(`should find a path between further points
+  it(`should find a path between distant points
     A>.
     ...
-    ..B
-  `, () => {
+    ..B`, () => {
     expect(
       pathfind(
         [[enemyMock], [], [undefined, undefined, playerMock]],
@@ -229,5 +227,60 @@ describe.only('pathfind', () => {
         1
       )
     ).toEqual({ x: 1, y: 0 });
+  });
+
+  it(`should go around obstacles
+    AX.
+    v..
+    ..B`, () => {
+    expect(
+      pathfind(
+        [[enemyMock], [playerMock], [undefined, undefined, playerMock]],
+        { x: 0, y: 0 },
+        { x: 2, y: 2 },
+        1
+      )
+    ).toEqual({ x: 0, y: 1 });
+  });
+
+  it(`should return cleanly if there's no path
+    A.X
+    .X.
+    X.B`, () => {
+    expect(
+      pathfind(
+        [
+          [enemyMock, playerMock],
+          [playerMock],
+          [playerMock, undefined, playerMock],
+        ],
+        { x: 0, y: 0 },
+        { x: 2, y: 2 },
+        1
+      )
+    ).toEqual(undefined);
+  });
+});
+
+describe('getFacing', () => {
+  it('should return facing properly in cardinal directions', () => {
+    expect(getFacing({ x: 0, y: 0 }, { x: 0, y: -3 })).toEqual('up');
+    expect(getFacing({ x: 0, y: 0 }, { x: 0, y: 3 })).toEqual('down');
+    expect(getFacing({ x: 0, y: 0 }, { x: -3, y: 0 })).toEqual('left');
+    expect(getFacing({ x: 0, y: 0 }, { x: 3, y: 0 })).toEqual('right');
+  });
+
+  it('should return facing at a semi-horizontal angle', () => {
+    expect(getFacing({ x: 0, y: 0 }, { x: 2, y: 1 })).toEqual('right');
+  });
+
+  it('should return facing at a semi-vertical angle', () => {
+    expect(getFacing({ x: 0, y: 0 }, { x: 1, y: 2 })).toEqual('down');
+  });
+
+  it('should return something valid at a full diagonal', () => {
+    expect(['up', 'down', 'left', 'right']).toContain(
+      getFacing({ x: 0, y: 0 }, { x: 1, y: 1 })
+    );
   });
 });

--- a/src/scenes/game/game.helpers.spec.ts
+++ b/src/scenes/game/game.helpers.spec.ts
@@ -1,12 +1,12 @@
 import * as expect from 'expect';
 import { PokemonObject } from '../../objects/pokemon.object';
-import { getNearestTarget } from './game.helpers';
+import { getNearestTarget, pathfind } from './game.helpers';
+
+// TODO: Probably want to fix this, @typescript-eslint/no-object-literal-type-assertion
+const playerMock = { side: 'player' } as PokemonObject;
+const enemyMock = { side: 'enemy' } as PokemonObject;
 
 describe('getNearestTarget', () => {
-  // TODO: Probably want to fix this, @typescript-eslint/no-object-literal-type-assertion
-  const playerMock = { side: 'player' } as PokemonObject;
-  const enemyMock = { side: 'enemy' } as PokemonObject;
-
   it(`should find an enemy if they're right next to the player
       ...
       .AB
@@ -197,5 +197,37 @@ describe('getNearestTarget', () => {
         4
       )
     ).toEqual({ x: 3, y: 2 });
+  });
+});
+
+describe.only('pathfind', () => {
+  it(`should find a path between two points
+    A>B
+    ...
+    ...
+  `, () => {
+    expect(
+      pathfind(
+        [[enemyMock], [], [playerMock]],
+        { x: 0, y: 0 },
+        { x: 2, y: 0 },
+        1
+      )
+    ).toEqual({ x: 1, y: 0 });
+  });
+
+  it(`should find a path between further points
+    A>.
+    ...
+    ..B
+  `, () => {
+    expect(
+      pathfind(
+        [[enemyMock], [], [undefined, undefined, playerMock]],
+        { x: 0, y: 0 },
+        { x: 2, y: 2 },
+        1
+      )
+    ).toEqual({ x: 1, y: 0 });
   });
 });

--- a/src/scenes/game/game.helpers.ts
+++ b/src/scenes/game/game.helpers.ts
@@ -7,10 +7,28 @@ export interface Coords {
   y: number;
 }
 
+/*
+  This file has a `getNearestTarget` and a `pathfind` function,
+  which are both implementations of breadth-first search.
+
+  The key difference is that `getNearestTarget` ignores collision,
+  looking for just the nearest Pokemon that can be targetted. 
+  `pathfind` is, as its name suggests, a proper pathfinding algorithm.
+
+  Both of these are needed, because certain attacks have range.
+  Some Pokemon can attack targets that they can't reach via movement.
+  As such, the targetting algorithm needs to ignore collisions.
+
+  If anyone can think of a cleaner way to do this, feel free to make a PR.
+
+  TODO: I can probably shrink these down to one function, or at least
+  share the BFS logic instead of doing some messy super-optimised code
+  in one function, and human-readable logic in the other.
+ */
+
 /**
  * Gets the nearest enemy for the Pokemon at the target coordinates
- * Uses a breadth-first search, checking squares 1 away, then 2, then 3 etc
- * going around clockwise starting at the right
+ * Uses a collisionless breadth-first search
  *
  * ie.
  *     5
@@ -91,10 +109,10 @@ export function pathfind(
     return undefined;
   }
 
+  // FIXME: Don't hardcode this length
   /** stores the fastest way to reach this step */
   let prev: Coords[][] = [[], [], [], [], []];
   let seen: boolean[][] = [[], [], [], [], []];
-  seen[start.x][start.y] = true;
 
   let queue = [start];
   while (queue.length > 0) {
@@ -116,10 +134,12 @@ export function pathfind(
     ].forEach(newCoord => {
       if (
         newCoord.x >= 0 &&
-        newCoord.x < prev.length &&
+        // FIXME: don't hardcode this length
+        newCoord.x < board.length &&
         newCoord.y >= 0 &&
         newCoord.y < board.length &&
-        !seen[newCoord.x][newCoord.y]
+        !seen[newCoord.x][newCoord.y] &&
+        !board[newCoord.x][newCoord.y]
       ) {
         queue.push(newCoord);
         seen[newCoord.x][newCoord.y] = true;

--- a/src/scenes/game/game.helpers.ts
+++ b/src/scenes/game/game.helpers.ts
@@ -1,4 +1,5 @@
 import { Pokemon } from '../../core/pokemon.model';
+import { PokemonAnimationType } from '../../objects/pokemon.object';
 import { GameScene } from './game.scene';
 
 export interface Coords {
@@ -70,6 +71,78 @@ export function getNearestTarget(
 }
 
 /**
+ * Builds a path from start to somewhere in range of the target
+ * Returns the first step in the path.
+ */
+export function pathfind(
+  board: GameScene['board'],
+  /** Self X and Y coordinates */
+  start: Coords,
+  /** Target's X and Y coordinates */
+  target: Coords,
+  /** Attack range to count as "reached" */
+  range: number
+): Coords | undefined {
+  // uses BFS
+  // TODO: if the AI ends up being super stupid, use an optimal-path algorithm instead
+
+  const self = board[start.x][start.y];
+  if (!self) {
+    return undefined;
+  }
+
+  /** stores the fastest way to reach this step */
+  let prev: Coords[][] = [[], [], [], [], []];
+  let seen: boolean[][] = [[], [], [], [], []];
+  seen[start.x][start.y] = true;
+
+  let queue = [start];
+  while (queue.length > 0) {
+    // lazy cast because the loop condition already checks there'll be an element
+    const check = queue.shift() as Coords;
+
+    // reached a goal state, end
+    if (getGridDistance(check, target) <= range) {
+      prev[target.x][target.y] = check;
+      break;
+    }
+
+    // else enqueue more items
+    [
+      { x: check.x + 1, y: check.y },
+      { x: check.x - 1, y: check.y },
+      { x: check.x, y: check.y + 1 },
+      { x: check.x, y: check.y - 1 },
+    ].forEach(newCoord => {
+      if (
+        newCoord.x >= 0 &&
+        newCoord.x < prev.length &&
+        newCoord.y >= 0 &&
+        newCoord.y < board.length &&
+        !seen[newCoord.x][newCoord.y]
+      ) {
+        queue.push(newCoord);
+        seen[newCoord.x][newCoord.y] = true;
+        prev[newCoord.x][newCoord.y] = check;
+      }
+    });
+  }
+
+  // trace back along the `prev` map to find the first step
+  let curr = target;
+  while (prev[curr.x][curr.y]) {
+    if (coordsEqual(prev[curr.x][curr.y], start)) {
+      return curr;
+    }
+    curr = prev[curr.x][curr.y];
+  }
+}
+
+export function coordsEqual(first: Coords, second: Coords) {
+  return first.x === second.x && first.y === second.y;
+}
+
+/**
  * Returns the Manhattan distance between two coordinates
  */
 export function getGridDistance(first: Coords, second: Coords) {
@@ -82,4 +155,17 @@ export function getGridDistance(first: Coords, second: Coords) {
  */
 export function getTurnDelay(pokemon: Pokemon) {
   return 100_000 / pokemon.speed;
+}
+
+export function getFacing(first: Coords, second: Coords): PokemonAnimationType {
+  const horizontal = second.x - first.x;
+  const vertical = second.y - first.y;
+
+  if (Math.abs(horizontal) > Math.abs(vertical)) {
+    // left or right
+    return horizontal < 0 ? 'left' : 'right';
+  } else {
+    // up or down
+    return vertical < 0 ? 'up' : 'down';
+  }
 }


### PR DESCRIPTION
This commit adds the ability for Pokemon to move when their target is out of range.
It currently uses a simple BFS to find the next step and moves the Pokemon to it.

TODO (maybe separately): handle the case when a Pokemon is blocked but can move closer.