### PR TITLE
Add board organisation (moving Pokemon) during downtime

### DIFF
--- a/src/objects/pokemon.object.ts
+++ b/src/objects/pokemon.object.ts
@@ -20,6 +20,12 @@ export class PokemonObject extends Phaser.GameObjects.Sprite {
     Dead: 'dead',
   } as const;
 
+  /**
+   * A hacky little way of adding an outline to a Pokemon.
+   * Draws a second, slightly larger sprite which serves as the outline.
+   */
+  private outlineSprite: Phaser.GameObjects.Sprite;
+
   private hpBar: Phaser.GameObjects.Graphics;
   private currentHP: number;
   private maxHP: number;
@@ -42,6 +48,13 @@ export class PokemonObject extends Phaser.GameObjects.Sprite {
     this.basePokemon = pokemonData[this.name];
     this.side = params.side;
 
+    this.outlineSprite = this.scene.add
+      .sprite(this.x, this.y, this.name, params.frame)
+      .setOrigin(0.5, 0.5)
+      .setDisplaySize(this.width + 8, this.height + 8)
+      .setTintFill(0xffffff)
+      .setVisible(false);
+
     // default state is facing the player
     this.playAnimation('down');
 
@@ -54,6 +67,9 @@ export class PokemonObject extends Phaser.GameObjects.Sprite {
 
   setPosition(x: number, y: number) {
     super.setPosition(x, y);
+    if (this.outlineSprite) {
+      this.outlineSprite.setPosition(x, y);
+    }
     if (this.hpBar) {
       this.hpBar.setPosition(x, y);
     }
@@ -91,6 +107,7 @@ export class PokemonObject extends Phaser.GameObjects.Sprite {
 
   public playAnimation(type: PokemonAnimationType) {
     this.play(`${this.name}--${type}`);
+    this.outlineSprite.play(`${this.name}--${type}`);
   }
 
   public move({ x, y }: Coords) {
@@ -142,5 +159,10 @@ export class PokemonObject extends Phaser.GameObjects.Sprite {
         callbackScope: this,
       });
     }
+  }
+
+  public toggleOutline(): this {
+    this.outlineSprite.setVisible(!this.outlineSprite.visible);
+    return this;
   }
 }

--- a/src/objects/pokemon.object.ts
+++ b/src/objects/pokemon.object.ts
@@ -25,6 +25,7 @@ export class PokemonObject extends Phaser.GameObjects.Sprite {
    * Draws a second, slightly larger sprite which serves as the outline.
    */
   private outlineSprite: Phaser.GameObjects.Sprite;
+  private isOutlined = false;
 
   private hpBar: Phaser.GameObjects.Graphics;
   private currentHP: number;
@@ -78,6 +79,7 @@ export class PokemonObject extends Phaser.GameObjects.Sprite {
 
   setVisible(visible: boolean) {
     this.hpBar.setVisible(visible);
+    this.outlineSprite.setVisible(visible && this.isOutlined);
     return super.setVisible(visible);
   }
 
@@ -162,7 +164,8 @@ export class PokemonObject extends Phaser.GameObjects.Sprite {
   }
 
   public toggleOutline(): this {
-    this.outlineSprite.setVisible(!this.outlineSprite.visible);
+    this.isOutlined = !this.isOutlined;
+    this.outlineSprite.setVisible(this.isOutlined);
     return this;
   }
 }

--- a/src/scenes/game/game.scene.ts
+++ b/src/scenes/game/game.scene.ts
@@ -215,6 +215,7 @@ export class GameScene extends Phaser.Scene {
       col.forEach(pokemon => pokemon && pokemon.setVisible(false))
     );
     this.prepGrid.setVisible(false);
+    this.input.enabled = false;
 
     const sceneData: CombatSceneData = {
       playerBoard: this.mainboard,
@@ -232,6 +233,7 @@ export class GameScene extends Phaser.Scene {
       col.forEach(pokemon => pokemon && pokemon.setVisible(true))
     );
     this.prepGrid.setVisible(true);
+    this.input.enabled = true;
 
     this.nextRoundButton = new Button(this, SIDEBOARD_X, 450, 'Next Round');
     this.nextRoundButton.on(Phaser.Input.Events.GAMEOBJECT_POINTER_DOWN, () => {

--- a/src/scenes/game/game.scene.ts
+++ b/src/scenes/game/game.scene.ts
@@ -236,6 +236,11 @@ export class GameScene extends Phaser.Scene {
   }
 
   startCombat() {
+    // deselect any selected Pokemon
+    if (this.selectedPokemon) {
+      this.selectedPokemon.toggleOutline();
+      this.selectedPokemon = undefined;
+    }
     // hide all the prep-only stuff
     this.mainboard.forEach(col =>
       col.forEach(pokemon => pokemon && pokemon.setVisible(false))

--- a/src/scenes/game/game.scene.ts
+++ b/src/scenes/game/game.scene.ts
@@ -43,7 +43,7 @@ function getCoordinatesForMainboard({ x, y }: Coords): Coords {
 
 /**
  * Returns the mainboard x and y coordinates for a graphical coordinate,
- * or returns undefined if the point isn't on the grid
+ * or `undefined` if the point isn't on the grid
  */
 function getMainboardLocationForCoordinates({
   x,
@@ -74,6 +74,10 @@ function getMainboardLocationForCoordinates({
   };
 }
 
+/**
+ * Returns the sideboard index for a graphical coordinate,
+ * or `undefined` if the point isn't within the sideboard
+ */
 function getSideboardLocationForCoordinates({
   x,
   y,
@@ -184,11 +188,12 @@ export class GameScene extends Phaser.Scene {
 
     this.prepGridHighlight = this.add
       .rectangle(
-        // 1 tile from the bottom
         GRID_X,
+        // y: 1 tile from the bottom
         GRID_Y + CELL_WIDTH * 1.5,
-        // width: stretches across all bottom rows
+        // width: stretches across all columns
         CELL_WIDTH * BOARD_WIDTH,
+        // height: 2 rows
         CELL_WIDTH * 2,
         // color: ligher colour highlight
         0xffffff,
@@ -333,7 +338,7 @@ export class GameScene extends Phaser.Scene {
 
   /**
    * Moves the currently selected Pokemon to the location determined by the `Pointer` event.
-   * If not valid location is specified, the Pokemon is deselected.
+   * If no valid location is specified, the Pokemon is deselected.
    */
   movePokemon(clickCoords: Coords) {
     const fromPokemon = this.selectedPokemon;
@@ -373,7 +378,7 @@ export class GameScene extends Phaser.Scene {
   }
 
   /**
-   * Assigns a Pokemon object to a given location without.
+   * Assigns a Pokemon object to a given location.
    *
    * WARNING: Doesn't do any checks or cleanup of the current Pokemon at that location.
    * Make sure that either the location is empty, or you're tracking the Pokemon there.

--- a/src/scenes/game/game.scene.ts
+++ b/src/scenes/game/game.scene.ts
@@ -56,7 +56,12 @@ function getMainboardLocationForCoordinates({
   // ie. the distance to the left edge of the grid
   const gridy = (y - 75) / CELL_WIDTH;
 
-  if (gridx < 0 || gridx >= BOARD_WIDTH || gridy < 0 || gridy >= BOARD_WIDTH) {
+  if (
+    gridx < 0 ||
+    gridx >= BOARD_WIDTH ||
+    gridy < BOARD_WIDTH - 2 || // you can only put Pokemon in the bottom half of the grid
+    gridy >= BOARD_WIDTH
+  ) {
     return undefined;
   }
 
@@ -121,6 +126,8 @@ export class GameScene extends Phaser.Scene {
 
   /** The grid used to display team composition during the downtime phase */
   prepGrid: Phaser.GameObjects.Grid;
+  /** A background for highlighting the valid regions to put Pokemon in */
+  prepGridHighlight: Phaser.GameObjects.Shape;
 
   constructor() {
     super({
@@ -175,6 +182,22 @@ export class GameScene extends Phaser.Scene {
       1 // line alpha: solid
     );
 
+    this.prepGridHighlight = this.add
+      .rectangle(
+        // 1 tile from the bottom
+        GRID_X,
+        GRID_Y + CELL_WIDTH * 1.5,
+        // width: stretches across all bottom rows
+        CELL_WIDTH * BOARD_WIDTH,
+        CELL_WIDTH * 2,
+        // color: ligher colour highlight
+        0xffffff,
+        // alpha: mostly transparent
+        0.2
+      )
+      .setZ(-1)
+      .setVisible(false);
+
     this.input.on(
       Phaser.Input.Events.POINTER_DOWN,
       (event: Phaser.Input.Pointer) => {
@@ -207,6 +230,9 @@ export class GameScene extends Phaser.Scene {
     if (!this.canAddPokemonToSideboard()) {
       this.addButton.destroy();
     }
+
+    // show the "valid range" highlight if a Pokemon is selected
+    this.prepGridHighlight.setVisible(!!this.selectedPokemon);
   }
 
   startCombat() {


### PR DESCRIPTION
This commit adds all the functionality required for moving Pokemon around during downtime.

This is done with a (scene-wide) click handler that uses some new helper functions to
figure out if a click is on a grid tile, and if it contains a Pokemon. Clicks on Pokemon will
select them, and subsequent clicks will move them (if valid).