### PR TITLE
Add a helper to generate random ids consistently

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,6 +1,13 @@
 // general JS helpers file
 
 /**
+ * Generate a random string for use as a unique identifier
+ */
+export function id(): string {
+  return (Math.random() * 10000000 + 1).toString();
+}
+
+/**
  * Flatten a multi-dimensional array down to a single dimension
  */
 export function flatten<T>(arr: T[][]): T[] {

--- a/src/objects/pokemon.object.ts
+++ b/src/objects/pokemon.object.ts
@@ -1,5 +1,6 @@
 import * as Phaser from 'phaser';
 import { Pokemon, pokemonData, PokemonName } from '../core/pokemon.model';
+import { id } from '../helpers';
 import { Coords, getTurnDelay } from '../scenes/game/combat/combat.helpers';
 import { FloatingText } from './floating-text.object';
 
@@ -7,7 +8,6 @@ interface SpriteParams {
   readonly scene: Phaser.Scene;
   readonly x: number;
   readonly y: number;
-  readonly id: string;
   readonly name: PokemonName;
   readonly frame?: string | number;
   readonly side: 'player' | 'enemy';
@@ -40,7 +40,8 @@ export class PokemonObject extends Phaser.Physics.Arcade.Sprite {
   constructor(params: SpriteParams) {
     super(params.scene, params.x, params.y, params.name, params.frame);
 
-    this.id = params.id;
+    // generate a random ID
+    this.id = id();
     this.name = params.name;
 
     // load data from Pokemon data

--- a/src/scenes/game/combat/combat.scene.ts
+++ b/src/scenes/game/combat/combat.scene.ts
@@ -1,6 +1,6 @@
 import { Scene } from 'phaser';
 import { PokemonName } from '../../../core/pokemon.model';
-import { flatten, isDefined } from '../../../helpers';
+import { flatten, id, isDefined } from '../../../helpers';
 import {
   PokemonAnimationType,
   PokemonObject,
@@ -151,7 +151,6 @@ export class CombatScene extends Scene {
     const coords = getCoordinatesForGrid({ x, y });
     const pokemon = new PokemonObject({
       scene: this,
-      id: `${name}${x}${y}`,
       name,
       side,
       ...coords,
@@ -285,7 +284,7 @@ export class CombatScene extends Scene {
           );
           this.physics.add.existing(this.add.existing(projectile));
           // store this in the `projectiles` map under a random key
-          const projectileKey = Math.random().toFixed(20);
+          const projectileKey = id();
           this.projectiles[projectileKey] = projectile;
           // cause event when it hits
           projectile.on(Phaser.GameObjects.Events.DESTROY, () => {

--- a/src/scenes/game/game.scene.ts
+++ b/src/scenes/game/game.scene.ts
@@ -153,7 +153,6 @@ export class GameScene extends Phaser.Scene {
       scene: this,
       x: 0,
       y: 0,
-      id: 'asdfgh',
       name: 'chandelure',
       side: 'enemy',
     });
@@ -329,7 +328,6 @@ export class GameScene extends Phaser.Scene {
       scene: this,
       ...getCoordinatesForSideboardIndex(empty),
       name: pokemon,
-      id: Math.random().toFixed(10),
       side: 'player',
     });
     this.add.existing(newPokemon);

--- a/src/scenes/menu.scene.ts
+++ b/src/scenes/menu.scene.ts
@@ -41,7 +41,6 @@ export class MenuScene extends Scene {
       scene: this,
       x: 400,
       y: 300,
-      id: randomPokemon,
       name: randomPokemon,
       side: 'player',
     }).setInteractive();


### PR DESCRIPTION
This commit adds a helper `id()` to generate random id strings for game objects
and various other things which need ideas. It also changes the `PokemonObject`
to automatically generate an id rather than be passed one.