### PR TITLE
[MVP] Add shop, can buy and reroll pokemon

### DIFF
--- a/src/core/pokemon.model.ts
+++ b/src/core/pokemon.model.ts
@@ -49,6 +49,7 @@ export interface Attack {
 export interface Pokemon {
   readonly name: string;
   readonly categories: ReadonlyArray<Category>;
+  readonly tier: number;
   readonly maxHP: number;
   readonly attack: number;
   readonly defense: number;
@@ -65,6 +66,7 @@ export const pokemonData = {
   chandelure: {
     name: 'Chandelure',
     categories: ['fire', 'ghost'],
+    tier: 2,
     maxHP: 60,
     attack: 55,
     defense: 90,
@@ -83,6 +85,7 @@ export const pokemonData = {
   talonflame: {
     name: 'Talonflame',
     categories: ['fire', 'flying', 'physical attacker'],
+    tier: 1,
     maxHP: 78,
     attack: 81,
     defense: 71,
@@ -97,6 +100,7 @@ export const pokemonData = {
   rotomw: {
     name: 'Rotom-W',
     categories: ['water', 'electric'],
+    tier: 1,
     maxHP: 50,
     attack: 65,
     defense: 107,

--- a/src/game.ts
+++ b/src/game.ts
@@ -4,6 +4,7 @@ import { GameScene } from './scenes/game/game.scene';
 import { LoadingScene } from './scenes/loading.scene';
 import { MenuScene } from './scenes/menu.scene';
 import { PreloadScene } from './scenes/preload.scene';
+import { ShopScene } from './scenes/game/shop.scene';
 
 export class PokemonAutochessGame extends Game {}
 
@@ -14,7 +15,7 @@ window.onload = () => {
     width: 800,
     height: 600,
     backgroundColor: '#3A4DB5',
-    scene: [PreloadScene, LoadingScene, MenuScene, CombatScene, GameScene],
+    scene: [PreloadScene, LoadingScene, MenuScene, CombatScene, GameScene, ShopScene],
     physics: {
       default: 'arcade',
     },

--- a/src/objects/player.object.ts
+++ b/src/objects/player.object.ts
@@ -1,0 +1,17 @@
+export class Player {
+  // all public props for now 
+  // just using to store the money at the moment
+  currentHP: number = 100;
+  maxHP: number = 100;
+  gold: number = 20;
+
+  /**
+   * Increases player gold from round win
+   * @returns The amount of gold gained
+   */
+  winGold(): number {
+    // TODO: calculate streaks etc.
+    ++this.gold;
+    return 1;
+  }
+}

--- a/src/objects/pokemon-for-sale.object.ts
+++ b/src/objects/pokemon-for-sale.object.ts
@@ -1,0 +1,41 @@
+import * as Phaser from 'phaser';
+import { pokemonData, PokemonName } from '../core/pokemon.model';
+import { Coords } from '../scenes/game/combat/combat.helpers';
+
+/**
+ * The pokemon object in the shop, including gold cost and any other elements
+ */
+export class PokemonForSaleObject {
+  public pokemonName: PokemonName;
+  public cost: number;
+
+  public scene: Phaser.Scene;
+  public centre: Coords;
+
+  private pokemonSprite: Phaser.GameObjects.Sprite;
+  private goldCostText: Phaser.GameObjects.Text;
+
+  constructor(scene: Phaser.Scene, coordinates: Coords, name: PokemonName) {
+    this.pokemonName = name;
+    this.cost = pokemonData[name].tier;
+    this.scene = scene;
+    this.centre = coordinates;
+
+    this.drawPokemon();
+    this.drawGoldCostText();
+  }
+
+  drawPokemon(): void {
+    this.pokemonSprite = this.scene.add.sprite(this.centre.x, this.centre.y, this.pokemonName);
+    this.pokemonSprite.play(`${this.pokemonName}--down`);
+  }
+
+  drawGoldCostText(): void {
+    this.goldCostText = this.scene.add.text(this.centre.x, this.centre.y + 50, this.cost.toString()).setOrigin(0.5);
+  }
+
+  destroy(): void {
+    this.pokemonSprite.destroy();
+    this.goldCostText.destroy();
+  }
+}

--- a/src/objects/pokemon.object.ts
+++ b/src/objects/pokemon.object.ts
@@ -89,6 +89,10 @@ export class PokemonObject extends Phaser.Physics.Arcade.Sprite {
     return super.setVisible(visible);
   }
 
+  setHPBarVisible(visible: boolean) {
+    this.hpBar.setVisible(visible);
+  }
+
   destroy() {
     this.hpBar.destroy();
     super.destroy();

--- a/src/scenes/game/game.scene.ts
+++ b/src/scenes/game/game.scene.ts
@@ -293,6 +293,7 @@ export class GameScene extends Phaser.Scene {
   }
 
   startDowntime() {
+    this.shop.reroll();
     // show all the prep-only stuff
     this.mainboard.forEach(col =>
       col.forEach(pokemon => pokemon && pokemon.setVisible(true))

--- a/src/scenes/game/game.scene.ts
+++ b/src/scenes/game/game.scene.ts
@@ -8,6 +8,8 @@ import {
   CombatScene,
   CombatSceneData,
 } from './combat/combat.scene';
+import { Player } from '../../objects/player.object';
+import { ShopScene } from './shop.scene';
 
 /** X-coordinate of the center of the grid */
 const GRID_X = 400;
@@ -21,6 +23,11 @@ const SIDEBOARD_X = 400;
 const SIDEBOARD_Y = 500;
 const CELL_WIDTH = 70;
 const CELL_COUNT = 8;
+
+//** X-coordinate of the center of the shop */
+const SHOP_X = 400
+//** Y-coordinate of the center of the shop */
+const SHOP_Y = 175;
 
 const MAX_MAINBOARD_POKEMON = 6;
 
@@ -116,8 +123,11 @@ export class GameScene extends Phaser.Scene {
 
   /* TEMPORARY JUNK */
   nextRoundButton: Button;
-  addButton: Phaser.GameObjects.GameObject;
+  shopButton: Phaser.GameObjects.GameObject;
   enemyBoard: CombatBoard;
+  player: Player;
+  playerGoldText: Phaser.GameObjects.Text;
+  playerHPText: Phaser.GameObjects.Text;
   /* END TEMPORARY JUNK */
 
   /** The Pokemon board representing the player's team composition */
@@ -132,6 +142,8 @@ export class GameScene extends Phaser.Scene {
   prepGrid: Phaser.GameObjects.Grid;
   /** A background for highlighting the valid regions to put Pokemon in */
   prepGridHighlight: Phaser.GameObjects.Shape;
+  
+  shop: ShopScene;
 
   constructor() {
     super({
@@ -202,6 +214,15 @@ export class GameScene extends Phaser.Scene {
       .setZ(-1)
       .setVisible(false);
 
+    this.player = new Player;
+    this.playerGoldText = this.add.text(50, 100, 'Gold: ' + this.player.gold);
+    this.playerHPText = this.add.text(50, 120, 'HP: ' + this.player.currentHP);
+
+    this.shop = this.scene.get(ShopScene.KEY) as ShopScene;
+    this.shop.player = this.player; // temporary solution
+    this.shop.setCentre({ x: SHOP_X, y: SHOP_Y });
+    this.scene.launch(ShopScene.KEY);
+
     this.input.on(
       Phaser.Input.Events.POINTER_DOWN,
       (event: Phaser.Input.Pointer) => {
@@ -213,13 +234,18 @@ export class GameScene extends Phaser.Scene {
       }
     );
 
-    this.addButton = this.add.existing(
-      new Button(this, 400, 580, 'Add Pokemon')
+    this.input.keyboard.on(
+      'keydown-SPACE',
+      () => {
+        this.toggleShop();
+      }
     );
-    this.addButton.on(Phaser.Input.Events.GAMEOBJECT_POINTER_DOWN, () =>
-      this.addPokemonToSideboard(
-        allPokemonNames[Math.floor(Math.random() * allPokemonNames.length)]
-      )
+
+    this.shopButton = this.add.existing(
+      new Button(this, 400, 580, 'Shop')
+    );
+    this.shopButton.on(Phaser.Input.Events.GAMEOBJECT_POINTER_DOWN, () =>
+      this.toggleShop()
     );
 
     this.nextRoundButton = new Button(this, SIDEBOARD_X, 450, 'Next Round');
@@ -231,10 +257,9 @@ export class GameScene extends Phaser.Scene {
   }
 
   update() {
-    if (!this.canAddPokemonToSideboard()) {
-      this.addButton.destroy();
-    }
-
+    this.playerGoldText.setText("Gold: " + this.player.gold);
+    this.playerHPText.setText('HP: ' + this.player.currentHP);
+    
     // show the "valid range" highlight if a Pokemon is selected
     this.prepGridHighlight.setVisible(!!this.selectedPokemon);
   }
@@ -256,6 +281,11 @@ export class GameScene extends Phaser.Scene {
       playerBoard: this.mainboard,
       enemyBoard: this.enemyBoard,
       callback: (winner: 'player' | 'enemy') => {
+        if (winner == 'player') {
+          this.player.winGold();
+        } else {
+          --this.player.currentHP; // TODO: implement properly
+        }
         this.startDowntime();
       },
     };
@@ -401,6 +431,19 @@ export class GameScene extends Phaser.Scene {
         const { x, y } = getCoordinatesForSideboardIndex(location.index);
         pokemon.setPosition(x, y);
       }
+    }
+  }
+
+  /**
+   * Opens or closes the shop
+   */
+  toggleShop() {
+    if (!this.scene.isPaused(ShopScene.KEY)) {
+      this.scene.pause(ShopScene.KEY);
+      this.scene.setVisible(false, ShopScene.KEY);
+    } else {
+      this.scene.resume(ShopScene.KEY);
+      this.scene.setVisible(true, ShopScene.KEY);
     }
   }
 }

--- a/src/scenes/game/shop.scene.ts
+++ b/src/scenes/game/shop.scene.ts
@@ -1,0 +1,172 @@
+import * as Phaser from 'phaser';
+import { Coords } from './combat/combat.helpers';
+import { PokemonObject } from '../../objects/pokemon.object';
+import { allPokemonNames, PokemonName } from '../../core/pokemon.model';
+import { Button } from '../../objects/button.object';
+import { Player } from '../../objects/player.object';
+import { GameScene } from './game.scene';
+
+const CELL_WIDTH = 70;
+const CELL_COUNT = 6;
+const POKEMON_OFFSET = 20;
+const REROLL_COST = 2;
+
+
+export class ShopScene extends Phaser.Scene {
+  static readonly KEY = 'ShopScene';
+  private centre: Coords = { x: 0, y: 0 };
+  private pokemonForSale: PokemonObject[] = new Array(CELL_COUNT);
+  private goldTexts: Phaser.GameObjects.Text[] = new Array(CELL_COUNT);
+
+  public player: Player;   // hacky temporary solution
+
+  constructor() {
+    super({
+      key: ShopScene.KEY,
+    });
+  }
+
+  preload(): void {  }
+
+  create(): void {
+    this.drawBase();
+    this.reroll();
+
+    let rerollButton = this.add.existing(
+      new Button(this, this.centre.x, this.centre.y + 60, 'Reroll')
+    );
+
+    rerollButton.on(Phaser.Input.Events.GAMEOBJECT_POINTER_DOWN, () => {
+      // maybe not best to be handled by the shop
+      if (this.player.gold >= REROLL_COST) {
+        this.player.gold -= REROLL_COST;
+        this.reroll();
+      } else {
+        console.log("Not enough gold to reroll");
+      }
+    });
+
+    this.input.on(
+      Phaser.Input.Events.POINTER_DOWN,
+      (event: Phaser.Input.Pointer) => {
+        let i = this.getShopIndexForCoordinates({ x: event.downX, y: event.downY} );
+        if (i != undefined) {
+          if (this.pokemonForSale[i] == undefined) { console.log("No pokemon here"); return; }
+
+          if (!this.buyPokemon(i)) { console.log("Not enough gold to buy this pokemon"); }
+        }
+      }
+    );
+  }
+
+  update(): void {  }
+
+  setCentre(centre: Coords): void {
+    this.centre = centre;
+  }
+
+  /**
+   * Draws the shop without the pokemon
+   */
+  drawBase(): void {
+    let width = (CELL_WIDTH * CELL_COUNT) + 100;
+    let height = CELL_WIDTH + 100;
+    this.add.rectangle(this.centre.x, this.centre.y, width, height, 0x2F4858);
+
+    this.add.grid(
+      this.centre.x,           // center x
+      this.centre.y - POKEMON_OFFSET,      // center y
+      CELL_WIDTH * CELL_COUNT, // total width
+      CELL_WIDTH,              // total height
+      CELL_WIDTH,              // cell width
+      CELL_WIDTH,              // cell height
+      0,                       // fill: none
+      0,                       // fill alpha: transparent
+      0xffaa00,                // lines: yellow
+      1                        // line alpha: solid
+    );
+  }
+
+  /**
+   * Refreshes the shop with new pokemon.
+   */
+  reroll(): void {
+    // Remove the old pokemon
+    for (let i in this.pokemonForSale) {
+      this.pokemonForSale[i].destroy();
+      this.goldTexts[i].destroy();
+      delete this.pokemonForSale[i];
+      delete this.goldTexts[i];
+    }
+
+    // For now, just populate with random pokemon
+    for (let i = 0; i < CELL_COUNT; ++i) {
+      let currCoords = this.getCoordinatesForShopIndex(i);
+      this.pokemonForSale[i] = new PokemonObject({
+        scene: this,
+        x: currCoords.x,
+        y: currCoords.y,
+        name: allPokemonNames[Math.floor(Math.random() * allPokemonNames.length)],
+        side: 'player',
+      });
+      this.pokemonForSale[i].setHPBarVisible(false);
+
+      this.add.existing(this.pokemonForSale[i]);
+      this.goldTexts[i] = this.add.text(currCoords.x, currCoords.y + 50, this.pokemonForSale[i].basePokemon.tier.toString()).setOrigin(0.5);
+    }
+  }
+
+  buyPokemon(index: number): boolean {
+    let price = this.pokemonForSale[index].basePokemon.tier
+    if (this.player.gold < price) {
+      return false;
+    }
+
+    let gameScene = this.scene.get(GameScene.KEY) as GameScene;
+    if (!gameScene.canAddPokemonToSideboard()) {
+      return false;
+    }
+
+    gameScene.addPokemonToSideboard(this.pokemonForSale[index].name);
+    this.pokemonForSale[index].destroy();
+    delete this.pokemonForSale[index];
+    this.player.gold -= price;
+    this.goldTexts[index].destroy();
+    delete this.goldTexts[index];
+    
+    return true;
+  }
+
+  /**
+   * Returns the graphical x and y coordinates for a spot in the sideboard.
+   */
+  getCoordinatesForShopIndex(i: number): Coords {
+    return {
+      x: this.centre.x + CELL_WIDTH * (i - (CELL_COUNT - 1) / 2),
+      y: this.centre.y - POKEMON_OFFSET
+    }
+  }
+
+  /**
+   * Returns the sideboard index for a graphical coordinate,
+   * or `undefined` if the point isn't within the sideboard
+   */
+  getShopIndexForCoordinates({
+    x,
+    y,
+  }: Coords): number | undefined {
+    // 35 = CELL_WIDTH / 2
+    // ie. the distance to the top of the sideboard
+    if (y < this.centre.y - POKEMON_OFFSET - 35 || y > this.centre.y - POKEMON_OFFSET + 35) {
+      return undefined;
+    }
+
+    // (this.centre.x - CELL_WIDTH * CELL_COUNT / 2)
+    // is the distance from start of grid to the left edge of the sideboard
+    const index = (x - (this.centre.x - CELL_WIDTH * CELL_COUNT / 2)) / CELL_WIDTH;
+    if (index < 0 || index >= CELL_COUNT) {
+      return undefined;
+    }
+    return Math.floor(index);
+  }
+}


### PR DESCRIPTION
Functionally:
- Open/close shop (hotkey: **SPACE** + button)
- Buy pokemon
- Track and award player money (basic)
- Reroll pokemon

Technically:
I feel like the interaction between scenes/objects is very hacky at the moment. I think we need to discuss how we will handle this in the future. 
The player state is super basic, really just for tracking money.