### PR TITLE
[MVP] Add sell functionality and streak bonus

### DIFF
--- a/src/objects/player.object.ts
+++ b/src/objects/player.object.ts
@@ -1,6 +1,4 @@
 export class Player {
-  // all public props for now
-  // just using to store the money at the moment
   currentHP: number = 100;
   maxHP: number = 100;
   gold: number = 20;
@@ -8,23 +6,37 @@ export class Player {
   streak: number = 0;
 
   /**
-   * Increases player gold from round
+   * Calculate streaks and award win gold
    * @param won True if the round was won by player
+   */
+  battleResult(won: boolean): void {
+    if (won) {
+      this.streak = Math.max(1, this.streak + 1);
+      ++this.gold;
+    } else {
+      --this.currentHP; // TODO implement properly
+      this.streak = Math.min(-1, this.streak - 1);
+    }
+  }
+
+  /**
+   * Increases player gold from round
    * @returns The amount of gold gained, including interest and streaks
    */
-  gainRoundEndGold(won: boolean): number {
-    // TODO: min/max cap the streaks (design/balance - right now gold gain is way too much)
-    // Interest is 10% rounded down
-    const interest = Math.floor(this.gold / 10);
+  gainRoundEndGold(): number {
     let goldGain = 1; // base gain
-    if (won) {
-      this.streak = Math.max(0, this.streak + 1);
-      ++goldGain;
-    } else {
-      this.streak = Math.min(0, this.streak - 1);
-    }
-    goldGain += interest + Math.max(0, Math.abs(this.streak) - 1);
+    goldGain += this.getInterest() + this.getStreakBonus();
     this.gold += goldGain;
     return goldGain;
+  }
+
+  getInterest(): number {
+    return Math.min(5, Math.floor(this.gold / 10));
+  }
+
+  getStreakBonus(): number {
+    // TODO: min/max cap the streaks for design/balance
+    // right now gold gain is way too much
+    return Math.max(0, Math.abs(this.streak) - 1);
   }
 }

--- a/src/objects/player.object.ts
+++ b/src/objects/player.object.ts
@@ -4,14 +4,27 @@ export class Player {
   currentHP: number = 100;
   maxHP: number = 100;
   gold: number = 20;
+  /** Consecutive win/loss streak */
+  streak: number = 0;
 
   /**
-   * Increases player gold from round win
-   * @returns The amount of gold gained
+   * Increases player gold from round
+   * @param won True if the round was won by player
+   * @returns The amount of gold gained, including interest and streaks
    */
-  winGold(): number {
-    // TODO: calculate streaks etc.
-    ++this.gold;
-    return 1;
+  gainRoundEndGold(won: boolean): number {
+    // TODO: min/max cap the streaks (design/balance - right now gold gain is way too much)
+    // Interest is 10% rounded down
+    const interest = Math.floor(this.gold / 10);
+    let goldGain = 1; // base gain
+    if (won) {
+      this.streak = Math.max(0, this.streak + 1);
+      ++goldGain;
+    } else {
+      this.streak = Math.min(0, this.streak - 1);
+    }
+    goldGain += interest + Math.max(0, Math.abs(this.streak) - 1);
+    this.gold += goldGain;
+    return goldGain;
   }
 }

--- a/src/scenes/game/game.scene.ts
+++ b/src/scenes/game/game.scene.ts
@@ -259,7 +259,7 @@ export class GameScene extends Phaser.Scene {
       .setVisible(false);
 
     this.sellArea.setInteractive().on('pointerdown', () => {
-      this.sellPokemon(this.selectedPokemon as PokemonObject);
+      this.sellPokemon(this.player, this.selectedPokemon as PokemonObject);
     });
 
     this.nextRoundButton = new Button(this, SIDEBOARD_X, 450, 'Next Round');
@@ -296,12 +296,7 @@ export class GameScene extends Phaser.Scene {
       playerBoard: this.mainboard,
       enemyBoard: this.enemyBoard,
       callback: (winner: 'player' | 'enemy') => {
-        if (winner === 'player') {
-          this.player.gainRoundEndGold(true); // TODO: do the actual gold gain at round start rather than immediately after combat
-        } else {
-          this.player.gainRoundEndGold(false);
-          --this.player.currentHP; // TODO: implement properly
-        }
+        this.player.battleResult(winner === 'player');
         this.startDowntime();
       },
     };
@@ -310,6 +305,8 @@ export class GameScene extends Phaser.Scene {
 
   startDowntime() {
     this.shop.reroll();
+    this.player.gainRoundEndGold();
+
     // show all the prep-only stuff
     this.mainboard.forEach(col =>
       col.forEach(pokemon => pokemon && pokemon.setVisible(true))
@@ -579,15 +576,14 @@ export class GameScene extends Phaser.Scene {
     }
   }
 
-  sellPokemon(pokemon: PokemonObject) {
+  sellPokemon(player: Player, pokemon: PokemonObject) {
     // TODO: add pokemon back into pool
-
     if (pokemon.basePokemon.stage === 1) {
-      this.player.gold += pokemon.basePokemon.tier;
+      player.gold += pokemon.basePokemon.tier;
     } else if (pokemon.basePokemon.stage === 2) {
-      this.player.gold += pokemon.basePokemon.tier + 2;
+      player.gold += pokemon.basePokemon.tier + 2;
     } else {
-      this.player.gold += pokemon.basePokemon.tier + 4;
+      player.gold += pokemon.basePokemon.tier + 4;
     }
 
     this.removePokemon(pokemon);


### PR DESCRIPTION
Streak bonus is not balanced, but we are tracking streaks at least.
Player gets...
* +1 gold for round end
* +1 gold for win
* +n gold for a n consecutive win streak

Sell pokemon at:
* Stage 1: Cost
* Stage 2: Cost + 2
* Stage 3: Cost + 4