### PR TITLE
Add pips in the HP bars to represent relative HP

### DIFF
--- a/src/objects/pokemon.object.ts
+++ b/src/objects/pokemon.object.ts
@@ -134,6 +134,21 @@ export class PokemonObject extends Phaser.Physics.Arcade.Sprite {
       this.width * (this.currentHP / this.maxHP) - 2,
       5
     );
+    // add little pips in the HP bar every 333 HP
+    this.bars.lineStyle(1, 0x000000, 1);
+    const width = Math.round((333 / this.maxHP) * (this.width - 2));
+    for (let x = width; x < this.width - 2; x += width) {
+      // full height bars for 1000 increments
+      const y = (x / width) % 3 === 0 ? 6 : 4;
+      this.bars.strokeLineShape(
+        new Phaser.Geom.Line(
+          -this.width / 2 + x,
+          -this.height / 2,
+          -this.width / 2 + x,
+          -this.height / 2 + y
+        )
+      );
+    }
 
     // pp bar
     this.bars.fillStyle(0x67aacb, 1); // sky blue


### PR DESCRIPTION
This commit adds little pips to the HP bars every 333 HP (ie. 3 per 1000 HP).

They look like this: 
![image](https://user-images.githubusercontent.com/8922125/64902034-8b082d80-d6e3-11e9-87b2-ac5726825bd6.png)
