### PR TITLE
 Support custom targetting logic for moves 

### DIFF
--- a/src/core/move.model.ts
+++ b/src/core/move.model.ts
@@ -1,4 +1,5 @@
 import { PokemonObject } from '../objects/pokemon.object';
+import { Coords } from '../scenes/game/combat/combat.helpers';
 
 export type Move = ActiveMove | PassiveMove;
 export interface MoveConfig {
@@ -14,6 +15,17 @@ interface ActiveMove {
   type: 'active';
   description: string;
   range: number;
+  /**
+   * Picks a target for the move and returns its coordinates,
+   * or undefined if no valid target eists
+   *
+   * Only needs to be defined for moves with special targetting
+   * (such as aoe moves, buffs, etc)
+   */
+  getTarget?(
+    user: PokemonObject,
+    board: (PokemonObject | undefined)[][]
+  ): Coords | undefined;
   /**
    * Use the move and trigger animations, effects, damage, etc.
    * Calls `onComplete` when all animations and effects are done.

--- a/src/core/move.model.ts
+++ b/src/core/move.model.ts
@@ -23,8 +23,8 @@ interface ActiveMove {
    * (such as aoe moves, buffs, etc)
    */
   getTarget?(
-    user: PokemonObject,
-    board: (PokemonObject | undefined)[][]
+    board: (PokemonObject | undefined)[][],
+    userCoords: Coords
   ): Coords | undefined;
   /**
    * Use the move and trigger animations, effects, damage, etc.

--- a/src/scenes/game/combat/combat.scene.ts
+++ b/src/scenes/game/combat/combat.scene.ts
@@ -246,28 +246,41 @@ export class CombatScene extends Scene {
       return;
     }
 
-    const targetCoords = getNearestTarget(
-      this.board,
-      myCoords,
-      BOARD_WIDTH,
-      BOARD_WIDTH
-    );
+    // use move if available, otherwise use basic attack
+    let selectedAttack =
+      pokemon.currentPP === pokemon.maxPP &&
+      pokemon.basePokemon.move &&
+      pokemon.basePokemon.move.type === 'active'
+        ? pokemon.basePokemon.move
+        : pokemon.basePokemon.basicAttack;
+    let selectedCoords =
+      'getTarget' in selectedAttack && selectedAttack.getTarget
+        ? selectedAttack.getTarget(pokemon, this.board)
+        : getNearestTarget(this.board, myCoords, BOARD_WIDTH, BOARD_WIDTH);
+
+    if (!selectedCoords) {
+      // if move has no valid target, fall back to basic attack
+      selectedAttack = pokemon.basePokemon.basicAttack;
+      selectedCoords = getNearestTarget(
+        this.board,
+        myCoords,
+        BOARD_WIDTH,
+        BOARD_WIDTH
+      );
+    }
+
+    // use const variables to make type inferencing neater below
+    const attack = selectedAttack;
+    const targetCoords = selectedCoords;
+
     if (!targetCoords) {
-      // do nothing and never do anything agian
+      // if basic attack has no valid target, do nothing and never do anything agian
       return;
     }
 
     // face target
     const facing = getFacing(myCoords, targetCoords);
     pokemon.playAnimation(facing);
-
-    // use move if available, otherwise use basic attack
-    const attack =
-      pokemon.currentPP === pokemon.maxPP &&
-      pokemon.basePokemon.move &&
-      pokemon.basePokemon.move.type === 'active'
-        ? pokemon.basePokemon.move
-        : pokemon.basePokemon.basicAttack;
 
     // move if out of range
     if (getGridDistance(myCoords, targetCoords) > attack.range) {

--- a/src/scenes/game/combat/combat.scene.ts
+++ b/src/scenes/game/combat/combat.scene.ts
@@ -255,7 +255,7 @@ export class CombatScene extends Scene {
         : pokemon.basePokemon.basicAttack;
     let selectedCoords =
       'getTarget' in selectedAttack && selectedAttack.getTarget
-        ? selectedAttack.getTarget(pokemon, this.board)
+        ? selectedAttack.getTarget(this.board, myCoords)
         : getNearestTarget(this.board, myCoords, BOARD_WIDTH, BOARD_WIDTH);
 
     if (!selectedCoords) {


### PR DESCRIPTION
This commit adds an optional `MoveConfig` field which allows you to provide an optional targeting function for the move. This will be useful for AoE moves which want to maximise targets, or for buffs/healing moves which want to target allies.

If `getFunction` is not provided, it uses the standard `getNearestTarget` as a default.