### PR TITLE
Add target optimisation for AOE moves

### DIFF
--- a/src/core/move.model.ts
+++ b/src/core/move.model.ts
@@ -2,20 +2,33 @@ import { PokemonObject } from '../objects/pokemon.object';
 import { Coords } from '../scenes/game/combat/combat.helpers';
 import { CombatScene } from '../scenes/game/combat/combat.scene';
 
-export type Move = ActiveMove | PassiveMove;
-export interface MoveConfig {
+export type Move = ActiveMove<'ground'> | ActiveMove<'unit'> | PassiveMove;
+export type Targetting = 'ground' | 'unit';
+
+export interface MoveConfig<T extends Targetting> {
   scene: CombatScene;
   board: (PokemonObject | undefined)[][];
   user: PokemonObject;
+  /** The targetted Pokemon for the move. Always exists if the move is unit-targetted */
+  target: T extends 'ground' ? PokemonObject | undefined : PokemonObject;
   targetCoords: Coords;
   onComplete: Function;
 }
 
-export interface ActiveMove {
+/**
+ * Moves which (typically) require PP and have to be used to have an effect
+ * The generic parameter is whether the move has a specific targetted unit or not (is ground targetted)
+ */
+export interface ActiveMove<T extends Targetting> {
   displayName: string;
   type: 'active';
   description: string;
   range: number;
+
+  /**
+   * Whether the move specifically targets a unit or not
+   */
+  targetting: T;
 
   /**
    * Picks a target for the move and returns its coordinates,
@@ -42,7 +55,7 @@ export interface ActiveMove {
    * Honestly I would rather have it return a Promise,
    * but a callback keeps it more consistent with Phaser.
    */
-  use(config: MoveConfig): void;
+  use(config: MoveConfig<T>): void;
 
   /* here follow a bunch of optional fields for damage and effect calculation */
 

--- a/src/core/move.model.ts
+++ b/src/core/move.model.ts
@@ -10,14 +10,13 @@ export interface MoveConfig<T extends Targetting> {
   board: (PokemonObject | undefined)[][];
   user: PokemonObject;
   /** The targetted Pokemon for the move. Always exists if the move is unit-targetted */
-  target: T extends 'ground' ? PokemonObject | undefined : PokemonObject;
+  target: T extends 'unit' ? PokemonObject : PokemonObject | undefined;
   targetCoords: Coords;
   onComplete: Function;
 }
 
 /**
  * Moves which (typically) require PP and have to be used to have an effect
- * The generic parameter is whether the move has a specific targetted unit or not (is ground targetted)
  */
 export interface ActiveMove<T extends Targetting> {
   displayName: string;

--- a/src/core/move.model.ts
+++ b/src/core/move.model.ts
@@ -7,7 +7,7 @@ export interface MoveConfig {
   scene: CombatScene;
   board: (PokemonObject | undefined)[][];
   user: PokemonObject;
-  target: PokemonObject;
+  targetCoords: Coords;
   onComplete: Function;
 }
 
@@ -16,6 +16,7 @@ export interface ActiveMove {
   type: 'active';
   description: string;
   range: number;
+
   /**
    * Picks a target for the move and returns its coordinates,
    * or undefined if no valid target eists
@@ -27,6 +28,13 @@ export interface ActiveMove {
     board: (PokemonObject | undefined)[][],
     userCoords: Coords
   ): Coords | undefined;
+
+  /**
+   * Returns the set of targetted squares for the move's area
+   * of effect when "centered" on a certain square
+   */
+  getAOE?(coords: Coords): Coords[];
+
   /**
    * Use the move and trigger animations, effects, damage, etc.
    * Calls `onComplete` when all animations and effects are done.

--- a/src/core/moves/brave-bird.ts
+++ b/src/core/moves/brave-bird.ts
@@ -26,7 +26,11 @@ export const braveBird: Move = {
     )} damage to a single target, with some recoil to the user.`;
   },
   range: 1,
-  use({ scene, user, target, onComplete }: MoveConfig) {
+  use({ scene, board, user, targetCoords, onComplete }: MoveConfig) {
+    const target = board[targetCoords.x][targetCoords.y];
+    if (!target) {
+      return onComplete();
+    }
     // animation: bird overlaying on top of Pokemon that grows
     const img = scene.add
       .image(user.x, user.y, 'brave-bird')

--- a/src/core/moves/brave-bird.ts
+++ b/src/core/moves/brave-bird.ts
@@ -20,17 +20,14 @@ export const braveBird: Move = {
   type: 'active',
   damage: [200, 350, 500],
   defenseStat: 'defense',
+  targetting: 'unit',
   get description() {
     return `Deals ${this.damage.join(
       '/'
     )} damage to a single target, with some recoil to the user.`;
   },
   range: 1,
-  use({ scene, board, user, targetCoords, onComplete }: MoveConfig) {
-    const target = board[targetCoords.x][targetCoords.y];
-    if (!target) {
-      return onComplete();
-    }
+  use({ scene, user, target, onComplete }: MoveConfig<'unit'>) {
     // animation: bird overlaying on top of Pokemon that grows
     const img = scene.add
       .image(user.x, user.y, 'brave-bird')

--- a/src/core/moves/razor-wind.ts
+++ b/src/core/moves/razor-wind.ts
@@ -18,6 +18,7 @@ export const razorWind: Move = {
   type: 'active',
   damage: [600, 1000, 1800],
   defenseStat: 'specDefense',
+  targetting: 'ground',
   get description() {
     return `After 2 seconds, whips up a whirlwind which deals ${this.damage.join(
       '/'
@@ -41,7 +42,7 @@ export const razorWind: Move = {
       { x: coords.x + 1, y: coords.y + 1 },
     ];
   },
-  use({ scene, user, targetCoords, board, onComplete }: MoveConfig) {
+  use({ scene, user, targetCoords, board, onComplete }: MoveConfig<'ground'>) {
     // double-hopping animation
     const gfxTarget = getCoordinatesForGrid(targetCoords);
     scene.add.tween({

--- a/src/core/moves/softboiled.spec.ts
+++ b/src/core/moves/softboiled.spec.ts
@@ -26,8 +26,8 @@ const lowEnemyMock = {
 
 describe('softboiled', () => {
   describe('getTarget', () => {
-    const softboiled = sb as ActiveMove;
-    let getTarget: NonNullable<ActiveMove['getTarget']>;
+    const softboiled = sb as ActiveMove<'unit'>;
+    let getTarget: NonNullable<typeof softboiled.getTarget>;
     before(() => {
       if (!softboiled.getTarget) {
         throw new Error('getTarget not defined for softboiled!');

--- a/src/core/moves/softboiled.ts
+++ b/src/core/moves/softboiled.ts
@@ -14,6 +14,7 @@ export const softboiled: Move = {
   displayName: 'Softboiled',
   type: 'active',
   damage: [300, 500, 700],
+  targetting: 'unit',
   get description() {
     return `Heals the lowest-health ally for ${this.damage.join('/')}`;
   },
@@ -35,12 +36,7 @@ export const softboiled: Move = {
     // clean pokemon out of coords
     return found ? { x: found.x, y: found.y } : undefined;
   },
-  use({ scene, board, user, targetCoords, onComplete }: MoveConfig) {
-    const target = board[targetCoords.x][targetCoords.y];
-    if (!target) {
-      return onComplete();
-    }
-
+  use({ scene, user, target, onComplete }: MoveConfig<'unit'>) {
     // hopping animation
     scene.add.tween({
       targets: [user],

--- a/src/core/moves/softboiled.ts
+++ b/src/core/moves/softboiled.ts
@@ -35,7 +35,12 @@ export const softboiled: Move = {
     // clean pokemon out of coords
     return found ? { x: found.x, y: found.y } : undefined;
   },
-  use({ scene, user, target, onComplete }: MoveConfig) {
+  use({ scene, board, user, targetCoords, onComplete }: MoveConfig) {
+    const target = board[targetCoords.x][targetCoords.y];
+    if (!target) {
+      return onComplete();
+    }
+
     // hopping animation
     scene.add.tween({
       targets: [user],

--- a/src/core/moves/thunder-wave.ts
+++ b/src/core/moves/thunder-wave.ts
@@ -5,7 +5,12 @@ export const thunderWave: Move = {
   type: 'active',
   description: 'Paralyses the target for 4 seconds.',
   range: 2,
-  use({ scene, user, target, onComplete }) {
+  use({ scene, board, user, targetCoords, onComplete }) {
+    const target = board[targetCoords.x][targetCoords.y];
+    if (!target) {
+      return onComplete();
+    }
+
     // hopping animation
     scene.add.tween({
       targets: [user],

--- a/src/core/moves/thunder-wave.ts
+++ b/src/core/moves/thunder-wave.ts
@@ -1,16 +1,12 @@
-import { Move } from '../move.model';
+import { Move, MoveConfig } from '../move.model';
 
 export const thunderWave: Move = {
   displayName: 'Thunder Wave',
   type: 'active',
   description: 'Paralyses the target for 4 seconds.',
   range: 2,
-  use({ scene, board, user, targetCoords, onComplete }) {
-    const target = board[targetCoords.x][targetCoords.y];
-    if (!target) {
-      return onComplete();
-    }
-
+  targetting: 'unit',
+  use({ scene, user, target, onComplete }: MoveConfig<'unit'>) {
     // hopping animation
     scene.add.tween({
       targets: [user],

--- a/src/core/moves/twineedle.ts
+++ b/src/core/moves/twineedle.ts
@@ -11,15 +11,11 @@ export const twineedle: Move = {
   displayName: 'Twineedle',
   type: 'active',
   range: 2,
+  targetting: 'unit',
   get description() {
     return `Every 3 / 2 / 1 attacks hits twice and poisons the target`;
   },
-  use({ scene, board, user, targetCoords, onComplete }: MoveConfig) {
-    const target = board[targetCoords.x][targetCoords.y];
-    if (!target) {
-      return onComplete();
-    }
-
+  use({ scene, user, target, onComplete }: MoveConfig<'unit'>) {
     const hitsToProc = [3, 2, 1];
     // hit once
     scene.basicAttack(user, target, () => {

--- a/src/core/moves/twineedle.ts
+++ b/src/core/moves/twineedle.ts
@@ -14,7 +14,12 @@ export const twineedle: Move = {
   get description() {
     return `Every 3 / 2 / 1 attacks hits twice and poisons the target`;
   },
-  use({ scene, user, target, onComplete }: MoveConfig) {
+  use({ scene, board, user, targetCoords, onComplete }: MoveConfig) {
+    const target = board[targetCoords.x][targetCoords.y];
+    if (!target) {
+      return onComplete();
+    }
+
     const hitsToProc = [3, 2, 1];
     // hit once
     scene.basicAttack(user, target, () => {

--- a/src/core/moves/volt-tackle.ts
+++ b/src/core/moves/volt-tackle.ts
@@ -25,7 +25,12 @@ export const voltTackle: Move = {
     )} damage to a single target, with some recoil to the user.`;
   },
   range: 1,
-  use({ scene, user, target, onComplete }: MoveConfig) {
+  use({ scene, board, user, targetCoords, onComplete }: MoveConfig) {
+    const target = board[targetCoords.x][targetCoords.y];
+    if (!target) {
+      return onComplete();
+    }
+
     // animation: some sparks then a tackle
     const sprite = scene.add
       .sprite(user.x, user.y, 'volt-tackle')

--- a/src/core/moves/volt-tackle.ts
+++ b/src/core/moves/volt-tackle.ts
@@ -19,18 +19,14 @@ export const voltTackle: Move = {
   type: 'active',
   damage: [300, 450, 600],
   defenseStat: 'defense',
+  targetting: 'unit',
   get description() {
     return `Deals ${this.damage.join(
       '/'
     )} damage to a single target, with some recoil to the user.`;
   },
   range: 1,
-  use({ scene, board, user, targetCoords, onComplete }: MoveConfig) {
-    const target = board[targetCoords.x][targetCoords.y];
-    if (!target) {
-      return onComplete();
-    }
-
+  use({ scene, user, target, onComplete }: MoveConfig<'unit'>) {
     // animation: some sparks then a tackle
     const sprite = scene.add
       .sprite(user.x, user.y, 'volt-tackle')

--- a/src/scenes/game/combat/combat.scene.ts
+++ b/src/scenes/game/combat/combat.scene.ts
@@ -36,7 +36,7 @@ const BOARD_WIDTH = 5;
 /**
  * Returns the graphical x and y coordinates for a spot in the battle grid.
  */
-function getCoordinatesForGrid({ x, y }: Coords): Coords {
+export function getCoordinatesForGrid({ x, y }: Coords): Coords {
   return { x: GRID_X + (x - 2) * CELL_WIDTH, y: GRID_Y + (y - 2) * CELL_WIDTH };
 }
 
@@ -298,11 +298,6 @@ export class CombatScene extends Scene {
       return;
     }
 
-    const targetPokemon = this.board[targetCoords.x][targetCoords.y];
-    if (!targetPokemon) {
-      return;
-    }
-
     // if it's a move, use it
     if ('use' in attack) {
       pokemon.currentPP = 0;
@@ -310,7 +305,7 @@ export class CombatScene extends Scene {
         scene: this,
         board: this.board,
         user: pokemon,
-        target: targetPokemon,
+        targetCoords,
         onComplete: () => {
           if (pokemon.currentHP > 0) {
             this.setTurn(pokemon);
@@ -318,6 +313,11 @@ export class CombatScene extends Scene {
         },
       });
       return;
+    }
+
+    const targetPokemon = this.board[targetCoords.x][targetCoords.y];
+    if (!targetPokemon) {
+      return this.setTurn(pokemon);
     }
 
     // otherwise make a basic attack

--- a/src/scenes/game/combat/combat.scene.ts
+++ b/src/scenes/game/combat/combat.scene.ts
@@ -298,14 +298,23 @@ export class CombatScene extends Scene {
       return;
     }
 
+    const targetPokemon = this.board[targetCoords.x][targetCoords.y];
+
     // if it's a move, use it
     if ('use' in attack) {
       pokemon.currentPP = 0;
+      if (attack.targetting === 'unit' && !targetPokemon) {
+        // end turn since there's no valid target
+        return this.setTurn(pokemon);
+      }
       attack.use({
         scene: this,
         board: this.board,
         user: pokemon,
         targetCoords,
+        // cast here because it's always PokemonObject when we need it to be
+        // we know because we just checkked `targetted && !targetPokemon`.
+        target: targetPokemon as PokemonObject,
         onComplete: () => {
           if (pokemon.currentHP > 0) {
             this.setTurn(pokemon);
@@ -315,8 +324,8 @@ export class CombatScene extends Scene {
       return;
     }
 
-    const targetPokemon = this.board[targetCoords.x][targetCoords.y];
     if (!targetPokemon) {
+      // end turn since there's no valid target
       return this.setTurn(pokemon);
     }
 


### PR DESCRIPTION
This commit adds support for optimising AOE moves by adding an `optimiseAOE` function which can be called from a move's custom `getTarget`.

In addition, certain AOE moves also need to be able to target the ground (and not a specific unit) in order to hit the maximum number of targets. This commit also adds differentiation between ground and unit targeted moves, only providing a `target: PokemonObject` to moves which need to target the ground. This is done via parametrising the `ActiveMove` type by `'ground'` or `'unit'`, so the type system enforces that unit targeted moves need a targetPokemon, while ground targeted ones don't. Doing it like this means we don't need `undefined` checks in every move's `use` function,