### PR TITLE
Support optimisation for unit-targetted AOEs and direction AOEs

### DIFF
--- a/src/core/move.model.ts
+++ b/src/core/move.model.ts
@@ -43,9 +43,11 @@ export interface ActiveMove<T extends Targetting> {
 
   /**
    * Returns the set of targetted squares for the move's area
-   * of effect when "centered" on a certain square
+   * of effect when "centered" on a certain square.
+   *
+   * This may involve the user's own coords (for directional attacks)
    */
-  getAOE?(coords: Coords): Coords[];
+  getAOE?(coords: Coords, myCoords: Coords): Coords[];
 
   /**
    * Use the move and trigger animations, effects, damage, etc.

--- a/src/scenes/game/combat/combat.helpers.spec.ts
+++ b/src/scenes/game/combat/combat.helpers.spec.ts
@@ -279,6 +279,15 @@ const crossAOEMock = (coords: Coords) => [
   { x: coords.x + 1, y: coords.y - 1 },
   { x: coords.x + 1, y: coords.y + 1 },
 ];
+// 2 square line in the direction of the target
+const directionLineAOEMock = (coords: Coords, myCoords: Coords) => {
+  const dx = coords.x - myCoords.x;
+  const dy = coords.y - myCoords.y;
+  return [
+    { x: myCoords.x + dx, y: myCoords.y + dy },
+    { x: myCoords.x + 2 * dx, y: myCoords.y + 2 * dy },
+  ];
+};
 
 describe('optimiseAOE', () => {
   it('should return nothing if there is nobody attacking', () => {
@@ -446,6 +455,46 @@ describe('optimiseAOE', () => {
         getAOE: crossAOEMock,
       })
     ).toEqual({ x: 2, y: 1 });
+  });
+
+  it(`should always pick a unit for a unit-targetted AOE
+       v
+      ABB
+      ..B
+      B.B`, () => {
+    // ie. it shouldn't be the center tile with 3 targets
+    expect(
+      optimiseAOE({
+        board: [
+          [playerMock, undefined, enemyMock],
+          [enemyMock, undefined, undefined],
+          [enemyMock, enemyMock, enemyMock],
+        ],
+        user: { x: 0, y: 0 },
+        range: 100,
+        getAOE: crossAOEMock,
+        targetting: 'unit',
+      })
+    ).toEqual({ x: 1, y: 0 });
+  });
+
+  it(`should work with moves that change AOE depending on user position
+       v
+      ABB
+      BBB
+      .BB`, () => {
+    expect(
+      optimiseAOE({
+        board: [
+          [playerMock, undefined, enemyMock],
+          [enemyMock, enemyMock, undefined],
+          [enemyMock, undefined, undefined],
+        ],
+        user: { x: 0, y: 0 },
+        range: 1,
+        getAOE: directionLineAOEMock,
+      })
+    ).toEqual({ x: 1, y: 0 });
   });
 });
 


### PR DESCRIPTION
Currently, the AOE optimisation assumes all AOEs are ground-targetted (which will not be the case). It also doesn't support moves that have different targets depending on the user's location (eg. directional moves). This commit adds support for both by add extra stuff to the models.