### PR TITLE
Save targets between turns

### DIFF
--- a/src/core/moves/dragon-rush.ts
+++ b/src/core/moves/dragon-rush.ts
@@ -100,6 +100,8 @@ export const dragonRush: Move = {
           board[x][y]?.takeDamage(damage);
         }
       });
+      // reset target after movement
+      user.currentTarget = undefined;
     }, 250);
   },
 } as const;

--- a/src/core/moves/ice-shard.ts
+++ b/src/core/moves/ice-shard.ts
@@ -91,6 +91,8 @@ export const iceShard: Move = {
           user.clearAlpha();
           onComplete();
         });
+        // reassign target after movement
+        user.currentTarget = weakestPokemon;
       }
     });
   },

--- a/src/core/moves/magnet-pull.ts
+++ b/src/core/moves/magnet-pull.ts
@@ -58,6 +58,10 @@ export const magnetPull: Move = {
     // move if possible
     if (moveCoords) {
       scene.movePokemon(targetCoords, moveCoords, () => {
+        // start attacking the pulled Pokemon
+        user.currentTarget = target;
+        // reset pulled Pokemon's targetting
+        target.currentTarget = undefined;
         onComplete();
       });
     }

--- a/src/objects/pokemon.object.ts
+++ b/src/objects/pokemon.object.ts
@@ -41,6 +41,7 @@ export class PokemonObject extends Phaser.Physics.Arcade.Sprite {
   id: string;
   side: 'player' | 'enemy';
   consecutiveAttacks = 0;
+  currentTarget?: PokemonObject;
 
   status: {
     [k in Status]?: {

--- a/src/scenes/game/combat/combat.scene.ts
+++ b/src/scenes/game/combat/combat.scene.ts
@@ -4,7 +4,7 @@ import { Attack, PokemonName } from '../../../core/pokemon.model';
 import { flatten, generateId, isDefined } from '../../../helpers';
 import {
   PokemonAnimationType,
-  PokemonObject
+  PokemonObject,
 } from '../../../objects/pokemon.object';
 import { Projectile } from '../../../objects/projectile.object';
 import {
@@ -15,7 +15,7 @@ import {
   getGridDistance,
   getNearestTarget,
   getTurnDelay,
-  pathfind
+  pathfind,
 } from './combat.helpers';
 
 export type CombatEndCallback = (winner: 'player' | 'enemy') => void;
@@ -293,9 +293,10 @@ export class CombatScene extends Scene {
       const step = pathfind(this.board, myCoords, targetCoords, attack.range);
       if (!step) {
         console.log('no valid step');
-        // can't reach: just do nothing and wait for next turn
+        // can't reach: just reset targetting and wait for next turn
         // FIXME: I'm pretty sure this will result in times when the Pokemon
         // will tunnel-vision and freeze up even if there are other valid targets
+        pokemon.currentTarget = undefined;
         this.setTurn(pokemon);
         return;
       }


### PR DESCRIPTION
Currently, targets are calculated at the start of each Pokemon's turn. Pokemon can switch targets if another Pokemon moves closer than their current target. Because the `getNearestTarget` is a BFS, it can cause a target switch even if the new target is the same distance.

This commit adds a `currentTarget` field to a `PokemonObject` which tracks the current target so it can be saved between turns. A few moves which trigger movement have been updated to reset targetting afterwards.