### PR TITLE
Add support for onHit synergies

### DIFF
--- a/src/core/game.model.ts
+++ b/src/core/game.model.ts
@@ -66,6 +66,7 @@ export interface Synergy {
     board: CombatScene['board'];
     attacker: PokemonObject;
     defender: PokemonObject;
+    damage: number;
     count: number;
   }) => void;
   /** Possible effect that occurs on being hit */
@@ -74,9 +75,10 @@ export interface Synergy {
     board: CombatScene['board'];
     attacker: PokemonObject;
     defender: PokemonObject;
+    damage: number;
     count: number;
   }) => void;
-  /** TODO Possible effect that occurs on start of round */
+  /** Possible effect that occurs on start of round */
   readonly onRoundStart?: (config: {
     scene: CombatScene;
     board: CombatScene['board'];
@@ -130,8 +132,36 @@ export const synergyData: { [k in Category]: Synergy } = {
   grass: {
     category: 'grass',
     displayName: 'Grass',
-    description: 'Does nothing.',
+    description: `All party members drain life when dealing damage.
+
+ (2) - 15% of damage
+ (4) - 30% of damage
+ (6) - 65% of damage`,
     thresholds: [2, 4, 6],
+    onHit({
+      attacker,
+      damage,
+      count,
+    }: {
+      attacker: PokemonObject;
+      damage: number;
+      count: number;
+    }) {
+      // TODO add animation for healing?
+      const tier = getSynergyTier(this.thresholds, count);
+      if (tier === 0) {
+        return;
+      }
+      switch (tier) {
+        case 1:
+          return attacker.heal(damage * 0.15);
+        case 2:
+          return attacker.heal(damage * 0.3);
+        case 3:
+          return attacker.heal(damage * 0.65);
+        default: // nothing
+      }
+    },
   },
   poison: {
     category: 'poison',

--- a/src/core/moves/brave-bird.ts
+++ b/src/core/moves/brave-bird.ts
@@ -59,7 +59,7 @@ export const braveBird: Move = {
               damage: this.damage[user.basePokemon.stage - 1],
               defenseStat: 'defense',
             });
-            target.takeDamage(damage);
+            scene.causeDamage(user, target, damage);
             user.takeDamage(Math.floor(damage / 4), false);
             onComplete();
           },

--- a/src/core/moves/dark-void.ts
+++ b/src/core/moves/dark-void.ts
@@ -55,7 +55,7 @@ export const darkVoid: Move = {
               damage: target.maxHP / 10,
               defenseStat: 'specDefense',
             });
-            target.takeDamage(damage, false);
+            scene.causeDamage(user, target, damage);
             user.heal(damage / 2);
           });
         }, 1000);

--- a/src/core/moves/darkest-lariat.ts
+++ b/src/core/moves/darkest-lariat.ts
@@ -53,7 +53,11 @@ export const darkestLariat: Move = {
     possibleTargets.forEach(coords => {
       const target = board[coords.x][coords.y];
       if (target?.side === getOppositeSide(user.side)) {
-        target.takeDamage(this.damage[user.basePokemon.stage - 1]);
+        scene.causeDamage(
+          user,
+          target,
+          this.damage[user.basePokemon.stage - 1]
+        );
       }
     });
   },

--- a/src/core/moves/dragon-rush.ts
+++ b/src/core/moves/dragon-rush.ts
@@ -4,6 +4,7 @@ import {
   getAngle,
   getFacing,
   getFurthestTarget,
+  getOppositeSide,
   optimiseAOE,
 } from '../../scenes/game/combat/combat.helpers';
 import { CombatBoard } from '../../scenes/game/combat/combat.scene';
@@ -96,8 +97,9 @@ export const dragonRush: Move = {
       scene.movePokemon(userCoords, targetCoords, onComplete);
       const damage = this.damage[user.basePokemon.stage - 1];
       this.getAOE(targetCoords, userCoords).forEach(({ x, y }) => {
-        if (board[x][y] && board[x][y]?.side !== user.side) {
-          board[x][y]?.takeDamage(damage);
+        const thisTarget = board[x][y];
+        if (thisTarget?.side === getOppositeSide(user.side)) {
+          scene.causeDamage(user, thisTarget, damage);
         }
       });
       // reset target after movement

--- a/src/core/moves/fury-cutter.ts
+++ b/src/core/moves/fury-cutter.ts
@@ -65,7 +65,7 @@ export const furyCutter: Move = {
                 1.5 ** user.consecutiveAttacks,
               defenseStat: 'defense',
             });
-            target.takeDamage(damage);
+            scene.causeDamage(user, target, damage);
           },
         });
       },

--- a/src/core/moves/leech-life.ts
+++ b/src/core/moves/leech-life.ts
@@ -37,7 +37,7 @@ export const leechLife: Move = {
           damage: this.damage[user.basePokemon.stage - 1],
           defenseStat: this.defenseStat,
         });
-        target.takeDamage(damage);
+        scene.causeDamage(user, target, damage);
 
         // play bee animation on the target
         const bees = scene.add

--- a/src/core/moves/magnet-pull.ts
+++ b/src/core/moves/magnet-pull.ts
@@ -51,9 +51,9 @@ export const magnetPull: Move = {
       ({ x, y }) => inBounds(board, { x, y }) && !board[x]?.[y]
     )[0];
 
+    scene.causeDamage(user, target, this.damage[user.basePokemon.stage - 1]);
     // paralyse
     target.addStatus('paralyse', 4000);
-    target.takeDamage(this.damage[user.basePokemon.stage - 1]);
     // move if possible
     if (moveCoords) {
       scene.movePokemon(targetCoords, moveCoords, () => {

--- a/src/core/moves/meteor-mash.ts
+++ b/src/core/moves/meteor-mash.ts
@@ -77,7 +77,7 @@ export const meteorMash: Move = {
               damage: this.damage[user.basePokemon.stage - 1],
               defenseStat: 'defense',
             });
-            target.takeDamage(damage);
+            scene.causeDamage(user, target, damage);
 
             if (
               inBounds(board, endCoords) &&
@@ -92,7 +92,7 @@ export const meteorMash: Move = {
                   damage: this.damage[user.basePokemon.stage - 1],
                   defenseStat: 'defense',
                 });
-                otherTarget.takeDamage(otherDamage);
+                scene.causeDamage(user, otherTarget, otherDamage);
                 otherTarget.addStatus('paralyse', 2000);
               }
             } else {

--- a/src/core/moves/night-daze.ts
+++ b/src/core/moves/night-daze.ts
@@ -34,7 +34,7 @@ export const nightDaze: Move = {
           damage: this.damage[user.basePokemon.stage - 1],
           defenseStat: 'defense',
         });
-        target.takeDamage(damage);
+        scene.causeDamage(user, target, damage);
         target.addStatus('blind', 3000);
         onComplete();
       },

--- a/src/core/moves/razor-wind.ts
+++ b/src/core/moves/razor-wind.ts
@@ -79,8 +79,7 @@ export const razorWind: Move = {
             this.getAOE(targetCoords).forEach(coord => {
               const pokemon = board[coord.x]?.[coord.y];
               if (pokemon && pokemon.side !== user.side) {
-                user.dealDamage(dph);
-                pokemon.takeDamage(dph);
+                scene.causeDamage(user, pokemon, dph);
               }
             });
             hits++;

--- a/src/core/moves/shadow-ball.ts
+++ b/src/core/moves/shadow-ball.ts
@@ -72,7 +72,7 @@ export const shadowBall: Move = {
                 damage: this.damage[user.basePokemon.stage - 1],
                 defenseStat: this.defenseStat,
               });
-              target.takeDamage(damage);
+              scene.causeDamage(user, target, damage);
               // TODO: don't apply this more than once ever
               target.changeStats({
                 specDefense: 0.5,

--- a/src/core/moves/shell-trap.ts
+++ b/src/core/moves/shell-trap.ts
@@ -84,7 +84,7 @@ export const shellTrap: Move = {
                 damage: this.damage[user.basePokemon.stage - 1],
                 defenseStat: 'specDefense',
               });
-              target.takeDamage(damage);
+              scene.causeDamage(user, target, damage);
             }
           });
         };

--- a/src/core/moves/stone-edge.ts
+++ b/src/core/moves/stone-edge.ts
@@ -75,7 +75,7 @@ export const stoneEdge: Move = {
               damage: realBaseDamage,
               defenseStat: 'defense',
             });
-            pokemon.takeDamage(damage);
+            scene.causeDamage(user, pokemon, damage);
           });
         }, animations['stone-edge-shoot'].duration / 2);
       });

--- a/src/core/moves/tri-attack.ts
+++ b/src/core/moves/tri-attack.ts
@@ -1,6 +1,7 @@
 import {
   Coords,
   getGridDistance,
+  getOppositeSide,
   optimiseAOE,
 } from '../../scenes/game/combat/combat.helpers';
 import {
@@ -84,8 +85,9 @@ export const triAttack: Move = {
             // set timeouts to inflict damage when the explosions occur
 
             // explosion 1: single target
-            if (board[targetCoords.x]?.[targetCoords.y]?.side !== user.side) {
-              board[targetCoords.x]?.[targetCoords.y]?.takeDamage(damage);
+            const singleTarget = board[targetCoords.x][targetCoords.y];
+            if (singleTarget?.side === getOppositeSide(user.side)) {
+              scene.causeDamage(user, singleTarget, damage);
             }
 
             // explosion 2: 9 squares
@@ -98,11 +100,12 @@ export const triAttack: Move = {
                 duration: 150,
                 ease: Phaser.Math.Easing.Quadratic.In,
                 onComplete: () => {
-                  this.getAOE(targetCoords).forEach(
-                    ({ x, y }) =>
-                      board[x]?.[y]?.side !== user.side &&
-                      board[x]?.[y]?.takeDamage(damage)
-                  );
+                  this.getAOE(targetCoords).forEach(({ x, y }) => {
+                    const thisTarget = board[x]?.[y];
+                    if (thisTarget?.side === getOppositeSide(user.side)) {
+                      scene.causeDamage(user, thisTarget, damage);
+                    }
+                  });
                 },
               });
             }, animations['tri-attack-fire'].duration);
@@ -117,11 +120,12 @@ export const triAttack: Move = {
                 duration: 150,
                 ease: Phaser.Math.Easing.Quadratic.In,
                 onComplete: () => {
-                  this.getAOE(targetCoords).forEach(
-                    ({ x, y }) =>
-                      board[x]?.[y]?.side !== user.side &&
-                      board[x]?.[y]?.takeDamage(damage)
-                  );
+                  this.getAOE(targetCoords).forEach(({ x, y }) => {
+                    const thisTarget = board[x]?.[y];
+                    if (thisTarget?.side === getOppositeSide(user.side)) {
+                      scene.causeDamage(user, thisTarget, damage);
+                    }
+                  });
                 },
               });
             }, animations['tri-attack-fire'].duration + animations['tri-attack-electric'].duration);

--- a/src/core/moves/volt-tackle.ts
+++ b/src/core/moves/volt-tackle.ts
@@ -46,7 +46,7 @@ export const voltTackle: Move = {
             damage: this.damage[user.basePokemon.stage - 1],
             defenseStat: 'defense',
           });
-          target.takeDamage(damage);
+          scene.causeDamage(user, target, damage);
           user.takeDamage(Math.floor(damage / 4), false);
           onComplete();
         },

--- a/src/core/moves/zap-cannon.ts
+++ b/src/core/moves/zap-cannon.ts
@@ -93,7 +93,7 @@ export const zapCannon: Move = {
                 damage: this.damage[user.basePokemon.stage - 1],
                 defenseStat: this.defenseStat,
               });
-              pokemon.takeDamage(damage);
+              scene.causeDamage(user, pokemon, damage);
             }
           });
         }, animations.thunder.duration * 0.5);

--- a/src/scenes/game/combat/combat.scene.ts
+++ b/src/scenes/game/combat/combat.scene.ts
@@ -427,8 +427,7 @@ export class CombatScene extends Scene {
         const onHit = () => {
           if (hits) {
             // if it hits, deal damage
-            attacker.dealDamage(damage);
-            defender.takeDamage(damage);
+            this.causeDamage(attacker, defender, damage);
           } else {
             // otherwise show miss text
             this.add.existing(
@@ -447,6 +446,36 @@ export class CombatScene extends Scene {
           });
         }
       },
+    });
+  }
+
+  /**
+   * Causes one Pokemon to damage another, triggering all related effects
+   */
+  causeDamage(
+    attacker: PokemonObject,
+    defender: PokemonObject,
+    amount: number
+  ) {
+    attacker.dealDamage(amount);
+    defender.takeDamage(amount);
+    this.synergies[attacker.side].forEach(synergy => {
+      synergyData[synergy.category].onHit?.({
+        scene: this,
+        board: this.board,
+        attacker,
+        defender,
+        count: synergy.count,
+      });
+    });
+    this.synergies[defender.side].forEach(synergy => {
+      synergyData[synergy.category].onBeingHit?.({
+        scene: this,
+        board: this.board,
+        attacker,
+        defender,
+        count: synergy.count,
+      });
     });
   }
 

--- a/src/scenes/game/combat/combat.scene.ts
+++ b/src/scenes/game/combat/combat.scene.ts
@@ -465,6 +465,7 @@ export class CombatScene extends Scene {
         board: this.board,
         attacker,
         defender,
+        damage: amount,
         count: synergy.count,
       });
     });
@@ -474,6 +475,7 @@ export class CombatScene extends Scene {
         board: this.board,
         attacker,
         defender,
+        damage: amount,
         count: synergy.count,
       });
     });


### PR DESCRIPTION
This commit moves damage trigger logic into the Combat scene so synergies can be triggered on dealing/taking damage.
It also adds the Grass-type synergy, which heals attackers on dealing damage.

Note that this will temporarily cause moves to gain PP, as the way this was previously blocked by not triggering `dealDamage` on the move user.