### PR TITLE
Add support for multiple players

### DIFF
--- a/src/core/game.model.ts
+++ b/src/core/game.model.ts
@@ -90,6 +90,7 @@ export interface Synergy {
   /** Possible effect that occurs on end of round, after combat has concluded */
   readonly onRoundEnd?: (config: {
     scene: GameScene;
+    board: CombatScene['board'];
     winner: 'player' | 'enemy';
     count: number;
   }) => void;
@@ -125,10 +126,12 @@ to Pick Up a Pokeball at end of round.
     thresholds: [3, 6],
     onRoundEnd({
       scene,
+      board,
       winner,
       count,
     }: {
       scene: GameScene;
+      board: CombatScene['board'];
       winner: 'player' | 'enemy';
       count: number;
     }) {
@@ -141,7 +144,7 @@ to Pick Up a Pokeball at end of round.
         return;
       }
 
-      flatten(scene.mainboard)
+      flatten(board)
         .filter(isDefined)
         .forEach(pokemon => {
           if (

--- a/src/objects/player.object.ts
+++ b/src/objects/player.object.ts
@@ -16,13 +16,14 @@ import { SynergyMarker } from './synergy-marker.object';
 const MAX_MAINBOARD_POKEMON = 6;
 
 export class Player extends Phaser.GameObjects.GameObject {
-  currentHP = 100;
-  maxHP = 100;
+  hp = 100;
   gold = 20;
   /** Consecutive win/loss streak */
   streak = 0;
   /** A map storing whether a Pokemon (by id) is currently evolving. */
   markedForEvolution: { [k: string]: boolean } = {};
+
+  nameInList: Phaser.GameObjects.Text;
 
   /** The Pokemon board representing the player's team composition */
   mainboard: CombatBoard = Array(5)
@@ -37,8 +38,23 @@ export class Player extends Phaser.GameObjects.GameObject {
   synergies: { category: Category; count: number }[] = [];
   synergyIcons: SynergyMarker[] = [];
 
-  constructor(scene: GameScene) {
+  constructor(
+    scene: GameScene,
+    public playerName: string,
+    x: number,
+    y: number
+  ) {
     super(scene, 'player');
+
+    this.nameInList = scene.add.text(x, y, `${this.playerName} - ${this.hp}`);
+  }
+
+  update() {
+    this.nameInList.setText(`${this.playerName} - ${this.hp}`);
+  }
+
+  updatePosition(x: number, y: number) {
+    this.nameInList.setPosition(x, y);
   }
 
   /**
@@ -50,7 +66,7 @@ export class Player extends Phaser.GameObjects.GameObject {
       this.streak = Math.max(1, this.streak + 1);
       ++this.gold;
     } else {
-      --this.currentHP; // TODO implement properly
+      --this.hp; // TODO implement properly
       this.streak = Math.min(-1, this.streak - 1);
     }
   }

--- a/src/objects/player.object.ts
+++ b/src/objects/player.object.ts
@@ -1,9 +1,45 @@
-export class Player {
+import { Category } from '../core/game.model';
+import { PokemonName } from '../core/pokemon.model';
+import { flatten, isDefined } from '../helpers';
+import { CombatBoard } from '../scenes/game/combat/combat.scene';
+import {
+  GameScene,
+  getCoordinatesForMainboard,
+  getCoordinatesForSideboardIndex,
+  getMainboardLocationForCoordinates,
+  getSideboardLocationForCoordinates,
+  PokemonLocation,
+} from '../scenes/game/game.scene';
+import { PokemonObject } from './pokemon.object';
+import { SynergyMarker } from './synergy-marker.object';
+
+const MAX_MAINBOARD_POKEMON = 6;
+
+export class Player extends Phaser.GameObjects.GameObject {
   currentHP = 100;
   maxHP = 100;
   gold = 20;
   /** Consecutive win/loss streak */
   streak = 0;
+  /** A map storing whether a Pokemon (by id) is currently evolving. */
+  markedForEvolution: { [k: string]: boolean } = {};
+
+  /** The Pokemon board representing the player's team composition */
+  mainboard: CombatBoard = Array(5)
+    .fill(undefined)
+    // fill + map rather than `fill` an array because
+    // `fill` will only initialise one array and fill with shallow copies
+    .map(() => Array(5).fill(undefined));
+
+  /** The Pokemon in the player's sideboard (spare Pokemon) */
+  sideboard: (PokemonObject | undefined)[] = Array(8).fill(undefined);
+
+  synergies: { category: Category; count: number }[] = [];
+  synergyIcons: SynergyMarker[] = [];
+
+  constructor(scene: GameScene) {
+    super(scene, 'player');
+  }
 
   /**
    * Calculate streaks and award win gold
@@ -30,13 +66,236 @@ export class Player {
     return goldGain;
   }
 
-  getInterest(): number {
+  private getInterest(): number {
     return Math.min(5, Math.floor(this.gold / 10));
   }
 
-  getStreakBonus(): number {
+  private getStreakBonus(): number {
     // TODO: min/max cap the streaks for design/balance
     // right now gold gain is way too much
     return Math.max(0, Math.abs(this.streak) - 1);
+  }
+
+  /**
+   * Returns the PokemonObject at the given location (if it exists)
+   */
+  getPokemonAtLocation(location?: PokemonLocation): PokemonObject | undefined {
+    if (!location) {
+      return undefined;
+    }
+    return location.location === 'mainboard'
+      ? this.mainboard[location.coords.x][location.coords.y]
+      : this.sideboard[location.index];
+  }
+
+  /**
+   * Assigns a Pokemon object to a given location.
+   *
+   * WARNING: Doesn't do any checks or cleanup of the current Pokemon at that location.
+   * Make sure that either the location is empty, or you're tracking the Pokemon there.
+   */
+  setPokemonAtLocation(location: PokemonLocation, pokemon?: PokemonObject) {
+    if (location.location === 'mainboard') {
+      this.mainboard[location.coords.x][location.coords.y] = pokemon;
+      // move sprite as well
+      if (pokemon) {
+        const { x, y } = getCoordinatesForMainboard(location.coords);
+        pokemon.setPosition(x, y);
+      }
+      this.updateSynergies();
+    } else {
+      this.sideboard[location.index] = pokemon;
+      // move sprite as well
+      if (pokemon) {
+        const { x, y } = getCoordinatesForSideboardIndex(location.index);
+        pokemon.setPosition(x, y);
+      }
+    }
+  }
+
+  addPokemonToSideboard(pokemon: PokemonName) {
+    if (!this.canAddPokemonToSideboard()) {
+      return;
+    }
+
+    // should never be -1 because we just checked
+    const empty = this.sideboard.findIndex(v => !v);
+    // insert new Pokemon
+    const newPokemon = new PokemonObject({
+      scene: this.scene,
+      ...getCoordinatesForSideboardIndex(empty),
+      name: pokemon,
+      side: 'player',
+    });
+    this.scene.add.existing(newPokemon);
+    this.sideboard[empty] = newPokemon;
+
+    /* check evolutions */
+    if (newPokemon.basePokemon.evolution) {
+      this.applyEvolutions(newPokemon);
+    }
+  }
+
+  /**
+   * Checks for possible evolutions that can be triggered by a Pokemon.
+   *
+   * For optimisation purposes, only checks one Pokemon.
+   * This should be fine if it's called every time a new Pokemon is added.
+   */
+  applyEvolutions(newPokemon: PokemonObject) {
+    const evolutionName = newPokemon.basePokemon.evolution;
+    if (!evolutionName) {
+      return;
+    }
+
+    // TODO: make this more imperative if the performance is bad
+    // it's probably fine though
+    const samePokemon =
+      // get all the Pokemon
+      [...flatten(this.mainboard), ...this.sideboard]
+        .filter(isDefined)
+        // that are have the same Name as this one
+        .filter(pokemon => pokemon.name === newPokemon.name)
+        // that aren't already evolving
+        .filter(pokemon => !this.markedForEvolution[pokemon.id])
+        // and pick the first three
+        .slice(0, 3);
+    if (samePokemon.length < 3) {
+      return;
+    }
+    const evoLocation =
+      getMainboardLocationForCoordinates(samePokemon[0]) ||
+      getSideboardLocationForCoordinates(samePokemon[0]);
+    if (!evoLocation) {
+      // should always be defined, but sure
+      console.error('Could not find place to put evolution');
+      return;
+    }
+
+    // mark these pokemon as evolving
+    samePokemon.forEach(pokemon => {
+      this.markedForEvolution[pokemon.id] = true;
+    });
+
+    // play a flashing animation for a bit
+    // not sure how to use tweens to get a flashing trigger of the outline
+    // so this just manually creates one using window.setTimeout
+    let timeout = 350;
+    let flashAnimation: number;
+    const toggleAnim = () => {
+      samePokemon.forEach(pokemon => pokemon.toggleOutline());
+      timeout *= 0.75;
+      flashAnimation = window.setTimeout(toggleAnim, timeout);
+    };
+    toggleAnim();
+
+    window.setTimeout(() => {
+      // end animation
+      window.clearInterval(flashAnimation);
+      // delete old Pokemon
+      samePokemon.forEach(pokemon => {
+        this.markedForEvolution[pokemon.id] = false;
+        this.removePokemon(pokemon);
+      });
+      // add new one
+      const evo = new PokemonObject({
+        scene: this.scene,
+        x: 0,
+        y: 0,
+        name: evolutionName,
+        side: 'player',
+      });
+      this.scene.add.existing(evo);
+      this.setPokemonAtLocation(evoLocation, evo);
+      // play animation to make it super clear
+      evo.setScale(1.5, 1.5);
+      this.scene.add.tween({
+        targets: [evo],
+        scaleX: 1,
+        scaleY: 1,
+        ease: Phaser.Math.Easing.Expo.InOut,
+        duration: 500,
+        onComplete: () => {
+          this.applyEvolutions(evo);
+        },
+      });
+    }, 1000);
+  }
+
+  removePokemon(pokemon: PokemonObject) {
+    const location =
+      getMainboardLocationForCoordinates(pokemon) ||
+      getSideboardLocationForCoordinates(pokemon);
+    if (!location) {
+      // just destroy since it's not displayed anyway?
+      return pokemon.destroy();
+    }
+
+    if (location.location === 'mainboard') {
+      const existing = this.mainboard[location.coords.x][location.coords.y];
+      this.mainboard[location.coords.x][location.coords.y] = undefined;
+      if (existing) {
+        existing.destroy();
+      }
+      this.updateSynergies();
+    } else {
+      const existing = this.sideboard[location.index];
+      this.sideboard[location.index] = undefined;
+      if (existing) {
+        existing.destroy();
+      }
+    }
+  }
+
+  updateSynergies() {
+    // build a map of synergy -> count
+    const synergyMap: { [k in Category]?: number } = {};
+    flatten(this.mainboard)
+      .filter(isDefined)
+      // todo: only count unique pokemon
+      .map(pokemon =>
+        pokemon.basePokemon.categories.forEach(category => {
+          const newValue = (synergyMap[category] ?? 0) + 1;
+          synergyMap[category] = newValue;
+        })
+      );
+    // convert to an array of existing synergies
+    this.synergies = Object.entries(synergyMap)
+      .map(([category, count]) =>
+        count ? { category: category as Category, count } : undefined
+      )
+      .filter(isDefined)
+      // order by count, then by type order
+      .sort((a, b) => {
+        if (b.count !== a.count) {
+          return b.count - a.count;
+        }
+        return b.category > a.category ? -1 : 1;
+      });
+    // clean up old icons
+    this.synergyIcons.forEach(icon => icon.destroy());
+    // and add new ones
+    this.synergyIcons = this.synergies.map(
+      ({ category, count }, index) =>
+        this.scene.add.existing(
+          new SynergyMarker(
+            this.scene,
+            40,
+            170 + index * SynergyMarker.height,
+            category as Category,
+            count
+          )
+        ) as SynergyMarker
+    );
+  }
+
+  canAddPokemonToMainboard() {
+    return (
+      flatten(this.mainboard).filter(v => !!v).length < MAX_MAINBOARD_POKEMON
+    );
+  }
+
+  canAddPokemonToSideboard() {
+    return this.sideboard.includes(undefined);
   }
 }

--- a/src/scenes/game/game.helpers.ts
+++ b/src/scenes/game/game.helpers.ts
@@ -1,0 +1,51 @@
+const names = [
+  'Red',
+  'Leaf',
+  'Blue',
+  'Ethan',
+  'Kris',
+  'Lyra',
+  'Silver',
+  'May',
+  'Brendan',
+  'Wally',
+  'Lucas',
+  'Dawn',
+  'Barry',
+  'Hilbert',
+  'Hilda',
+  'Cheren',
+  'Bianca',
+  'Nate',
+  'Rosa',
+  'Hugh',
+  'Calem',
+  'Serena',
+  'Elio',
+  'Selene',
+  'Hau',
+  'Gladion',
+  'Victor',
+  'Gloria',
+  'Hop',
+  'Bede',
+  'Marnie',
+];
+
+/**
+ * Returns `amount` random names from the name list, with no repeats.
+ *
+ * note: this irreversibly modifies the original array,
+ * but it shouldn't matter because we don't use that directly.
+ */
+export function getRandomNames(amount: number): string[] {
+  // shuffle the list with a bastardised Fisher-Yates:
+  // for each item (up to the limit we care about)
+  for (let i = 0; i < amount; i++) {
+    // pick a random other element (that we haven't already swapped)
+    const swapIndex = Math.floor(Math.random() * (names.length - i)) + i;
+    // and swap the two (fancy ES6 syntax)
+    [names[i], names[swapIndex]] = [names[swapIndex], names[i]];
+  }
+  return names.slice(0, amount);
+}

--- a/src/scenes/game/game.scene.ts
+++ b/src/scenes/game/game.scene.ts
@@ -1,4 +1,4 @@
-import { Category, synergyData } from '../../core/game.model';
+import { synergyData } from '../../core/game.model';
 import {
   allPokemonNames,
   buyablePokemon,
@@ -9,13 +9,8 @@ import { flatten, isDefined } from '../../helpers';
 import { Button } from '../../objects/button.object';
 import { Player } from '../../objects/player.object';
 import { PokemonObject } from '../../objects/pokemon.object';
-import { SynergyMarker } from '../../objects/synergy-marker.object';
 import { Coords, inBounds } from './combat/combat.helpers';
-import {
-  CombatBoard,
-  CombatScene,
-  CombatSceneData,
-} from './combat/combat.scene';
+import { CombatScene, CombatSceneData } from './combat/combat.scene';
 import { ShopScene } from './shop.scene';
 
 /** X-coordinate of the center of the grid */
@@ -36,8 +31,6 @@ const SHOP_X = 400;
 /** Y-coordinate of the center of the shop */
 const SHOP_Y = 175;
 
-const MAX_MAINBOARD_POKEMON = 6;
-
 const POOL_SIZES = {
   1: 3,
   2: 3,
@@ -46,10 +39,14 @@ const POOL_SIZES = {
   5: 3,
 };
 
+export type PokemonLocation =
+  | { location: 'mainboard'; coords: Coords }
+  | { location: 'sideboard'; index: number };
+
 /**
  * Returns the graphical x and y coordinates for a spot in the sideboard.
  */
-function getCoordinatesForSideboardIndex(i: number): Coords {
+export function getCoordinatesForSideboardIndex(i: number): Coords {
   return {
     x: SIDEBOARD_X + CELL_WIDTH * (i - (CELL_COUNT - 1) / 2),
     y: SIDEBOARD_Y,
@@ -59,7 +56,7 @@ function getCoordinatesForSideboardIndex(i: number): Coords {
 /**
  * Returns the graphical x and y coordinates for a spot in the mainboard
  */
-function getCoordinatesForMainboard({ x, y }: Coords): Coords {
+export function getCoordinatesForMainboard({ x, y }: Coords): Coords {
   return { x: GRID_X + (x - 2) * CELL_WIDTH, y: GRID_Y + (y - 2) * CELL_WIDTH };
 }
 
@@ -67,7 +64,7 @@ function getCoordinatesForMainboard({ x, y }: Coords): Coords {
  * Returns the mainboard x and y coordinates for a graphical coordinate,
  * or `undefined` if the point isn't on the grid
  */
-function getMainboardLocationForCoordinates({
+export function getMainboardLocationForCoordinates({
   x,
   y,
 }: Coords): PokemonLocation | undefined {
@@ -100,7 +97,7 @@ function getMainboardLocationForCoordinates({
  * Returns the sideboard index for a graphical coordinate,
  * or `undefined` if the point isn't within the sideboard
  */
-function getSideboardLocationForCoordinates({
+export function getSideboardLocationForCoordinates({
   x,
   y,
 }: Coords): PokemonLocation | undefined {
@@ -122,10 +119,6 @@ function getSideboardLocationForCoordinates({
   };
 }
 
-type PokemonLocation =
-  | { location: 'mainboard'; coords: Coords }
-  | { location: 'sideboard'; index: number };
-
 /**
  * The main game scene.
  *
@@ -142,10 +135,11 @@ export class GameScene extends Phaser.Scene {
     [k in PokemonName]?: number;
   } = {};
 
+  players: Player[];
+
   /* TEMPORARY JUNK */
   nextRoundButton: Button;
   shopButton: Phaser.GameObjects.GameObject;
-  enemyBoard: CombatBoard;
   player: Player;
   playerGoldText: Phaser.GameObjects.Text;
   playerHPText: Phaser.GameObjects.Text;
@@ -153,23 +147,13 @@ export class GameScene extends Phaser.Scene {
   sellText: Phaser.GameObjects.Text;
   /* END TEMPORARY JUNK */
 
-  /** The Pokemon board representing the player's team composition */
-  mainboard: CombatBoard;
-  /** The Pokemon in the player's sideboard (spare Pokemon) */
-  sideboard: (PokemonObject | undefined)[] = Array(8).fill(undefined);
-
   /** A reference to the currently selected Pokemon */
   selectedPokemon?: PokemonObject;
-  /** A map storing whether a Pokemon (by id) is currently evolving. */
-  markedForEvolution: { [k: string]: boolean } = {};
 
   /** The grid used to display team composition during the downtime phase */
   prepGrid: Phaser.GameObjects.Grid;
   /** A background for highlighting the valid regions to put Pokemon in */
   prepGridHighlight: Phaser.GameObjects.Shape;
-
-  synergies: { category: Category; count: number }[] = [];
-  synergyIcons: Phaser.GameObjects.GameObject[] = [];
 
   shop: ShopScene;
 
@@ -180,23 +164,6 @@ export class GameScene extends Phaser.Scene {
   }
 
   init() {
-    this.mainboard = Array(5)
-      .fill(undefined)
-      // fill + map rather than `fill` an array because
-      // `fill` will only initialise one array and fill with shallow copies
-      .map(() => Array(5).fill(undefined));
-
-    this.enemyBoard = Array(5)
-      .fill(undefined)
-      .map(() => Array(5).fill(undefined));
-    this.enemyBoard[0][3] = new PokemonObject({
-      scene: this,
-      x: 0,
-      y: 0,
-      name: 'darkrai-2',
-      side: 'enemy',
-    });
-
     buyablePokemon.forEach(pokemon => {
       this.pool[pokemon] = POOL_SIZES[pokemonData[pokemon].tier];
     });
@@ -246,7 +213,9 @@ export class GameScene extends Phaser.Scene {
       .setZ(-1)
       .setVisible(false);
 
-    this.player = new Player();
+    this.players = new Array(8).fill(undefined).map(() => new Player(this));
+    // players[0] is always the human player
+    [this.player] = this.players;
     this.playerGoldText = this.add.text(50, 100, `Gold: ${this.player.gold}`);
     this.playerHPText = this.add.text(50, 120, `HP: ${this.player.currentHP}`);
 
@@ -315,7 +284,7 @@ export class GameScene extends Phaser.Scene {
       this.selectedPokemon = undefined;
     }
     // hide all the prep-only stuff
-    this.mainboard.forEach(col =>
+    this.player.mainboard.forEach(col =>
       col.forEach(pokemon => pokemon?.setVisible(false))
     );
     this.prepGrid.setVisible(false);
@@ -327,15 +296,16 @@ export class GameScene extends Phaser.Scene {
     }
 
     const sceneData: CombatSceneData = {
-      playerBoard: this.mainboard,
-      playerSynergies: this.synergies,
+      playerBoard: this.player.mainboard,
+      playerSynergies: this.player.synergies,
       // enemyBoard: this.enemyBoard,
       enemyBoard: this.generateEnemyBoard(),
       enemySynergies: [],
       callback: (winner: 'player' | 'enemy') => {
-        this.synergies.forEach(synergy => {
+        this.player.synergies.forEach(synergy => {
           synergyData[synergy.category].onRoundEnd?.({
             scene: this,
+            board: this.player.mainboard,
             winner,
             count: synergy.count,
           });
@@ -349,10 +319,10 @@ export class GameScene extends Phaser.Scene {
 
   startDowntime() {
     this.shop.reroll();
-    this.player.gainRoundEndGold();
+    this.players.forEach(player => player.gainRoundEndGold());
 
     // show all the prep-only stuff
-    this.mainboard.forEach(col =>
+    this.player.mainboard.forEach(col =>
       col.forEach(pokemon => pokemon?.setVisible(true))
     );
     this.prepGrid.setVisible(true);
@@ -374,57 +344,12 @@ export class GameScene extends Phaser.Scene {
       getMainboardLocationForCoordinates(clickCoords) ||
       getSideboardLocationForCoordinates(clickCoords);
 
-    const pokemon = this.getPokemonAtLocation(select);
+    const pokemon = this.player.getPokemonAtLocation(select);
     if (!pokemon) {
       return;
     }
 
     this.selectedPokemon = pokemon.toggleOutline();
-  }
-
-  /**
-   * Returns the PokemonObject at the given location (if it exists)
-   */
-  getPokemonAtLocation(location?: PokemonLocation): PokemonObject | undefined {
-    if (!location) {
-      return undefined;
-    }
-    return location.location === 'mainboard'
-      ? this.mainboard[location.coords.x][location.coords.y]
-      : this.sideboard[location.index];
-  }
-
-  canAddPokemonToMainboard() {
-    return (
-      flatten(this.mainboard).filter(v => !!v).length < MAX_MAINBOARD_POKEMON
-    );
-  }
-
-  canAddPokemonToSideboard() {
-    return this.sideboard.includes(undefined);
-  }
-
-  addPokemonToSideboard(pokemon: PokemonName) {
-    if (!this.canAddPokemonToSideboard()) {
-      return;
-    }
-
-    // should never be -1 because we just checked
-    const empty = this.sideboard.findIndex(v => !v);
-    // insert new Pokemon
-    const newPokemon = new PokemonObject({
-      scene: this,
-      ...getCoordinatesForSideboardIndex(empty),
-      name: pokemon,
-      side: 'player',
-    });
-    this.add.existing(newPokemon);
-    this.sideboard[empty] = newPokemon;
-
-    /* check evolutions */
-    if (newPokemon.basePokemon.evolution) {
-      this.applyEvolutions(newPokemon);
-    }
   }
 
   /**
@@ -456,198 +381,21 @@ export class GameScene extends Phaser.Scene {
     }
 
     // check if a Pokemon already exists here
-    const swapTarget = this.getPokemonAtLocation(toLocation);
+    const swapTarget = this.player.getPokemonAtLocation(toLocation);
 
     // don't move add to mainboard if there's no room
     if (
       toLocation.location === 'mainboard' &&
       fromLocation.location === 'sideboard' &&
-      !this.canAddPokemonToMainboard() &&
+      !this.player.canAddPokemonToMainboard() &&
       // can still swap
       !swapTarget
     ) {
       return;
     }
 
-    this.setPokemonAtLocation(toLocation, fromPokemon);
-    this.setPokemonAtLocation(fromLocation, swapTarget);
-  }
-
-  /**
-   * Assigns a Pokemon object to a given location.
-   *
-   * WARNING: Doesn't do any checks or cleanup of the current Pokemon at that location.
-   * Make sure that either the location is empty, or you're tracking the Pokemon there.
-   */
-  setPokemonAtLocation(location: PokemonLocation, pokemon?: PokemonObject) {
-    if (location.location === 'mainboard') {
-      this.mainboard[location.coords.x][location.coords.y] = pokemon;
-      // move sprite as well
-      if (pokemon) {
-        const { x, y } = getCoordinatesForMainboard(location.coords);
-        pokemon.setPosition(x, y);
-      }
-      this.updateSynergies();
-    } else {
-      this.sideboard[location.index] = pokemon;
-      // move sprite as well
-      if (pokemon) {
-        const { x, y } = getCoordinatesForSideboardIndex(location.index);
-        pokemon.setPosition(x, y);
-      }
-    }
-  }
-
-  removePokemon(pokemon: PokemonObject) {
-    const location =
-      getMainboardLocationForCoordinates(pokemon) ||
-      getSideboardLocationForCoordinates(pokemon);
-    if (!location) {
-      // just destroy since it's not displayed anyway?
-      return pokemon.destroy();
-    }
-
-    if (location.location === 'mainboard') {
-      const existing = this.mainboard[location.coords.x][location.coords.y];
-      this.mainboard[location.coords.x][location.coords.y] = undefined;
-      if (existing) {
-        existing.destroy();
-      }
-      this.updateSynergies();
-    } else {
-      const existing = this.sideboard[location.index];
-      this.sideboard[location.index] = undefined;
-      if (existing) {
-        existing.destroy();
-      }
-    }
-  }
-
-  updateSynergies() {
-    // build a map of synergy -> count
-    const synergyMap: { [k in Category]?: number } = {};
-    flatten(this.mainboard)
-      .filter(isDefined)
-      // todo: only count unique pokemon
-      .map(pokemon =>
-        pokemon.basePokemon.categories.forEach(category => {
-          const newValue = (synergyMap[category] ?? 0) + 1;
-          synergyMap[category] = newValue;
-        })
-      );
-    // convert to an array of existing synergies
-    this.synergies = Object.entries(synergyMap)
-      .map(([category, count]) =>
-        count ? { category: category as Category, count } : undefined
-      )
-      .filter(isDefined)
-      // order by count, then by type order
-      .sort((a, b) => {
-        if (b.count !== a.count) {
-          return b.count - a.count;
-        }
-        return b.category > a.category ? -1 : 1;
-      });
-    // clean up old icons
-    this.synergyIcons.forEach(icon => icon.destroy());
-    // and add new ones
-    this.synergyIcons = this.synergies.map(({ category, count }, index) =>
-      this.add.existing(
-        new SynergyMarker(
-          this,
-          40,
-          170 + index * SynergyMarker.height,
-          category as Category,
-          count
-        )
-      )
-    );
-  }
-
-  /**
-   * Checks for possible evolutions that can be triggered by a Pokemon.
-   *
-   * For optimisation purposes, only checks one Pokemon.
-   * This should be fine if it's called every time a new Pokemon is added.
-   */
-  applyEvolutions(newPokemon: PokemonObject) {
-    const evolutionName = newPokemon.basePokemon.evolution;
-    if (!evolutionName) {
-      return;
-    }
-
-    // TODO: make this more imperative if the performance is bad
-    // it's probably fine though
-    const samePokemon =
-      // get all the Pokemon
-      [...flatten(this.mainboard), ...this.sideboard]
-        .filter(isDefined)
-        // that are have the same Name as this one
-        .filter(pokemon => pokemon.name === newPokemon.name)
-        // that aren't already evolving
-        .filter(pokemon => !this.markedForEvolution[pokemon.id])
-        // and pick the first three
-        .slice(0, 3);
-    if (samePokemon.length < 3) {
-      return;
-    }
-    const evoLocation =
-      getMainboardLocationForCoordinates(samePokemon[0]) ||
-      getSideboardLocationForCoordinates(samePokemon[0]);
-    if (!evoLocation) {
-      // should always be defined, but sure
-      console.error('Could not find place to put evolution');
-      return;
-    }
-
-    // mark these pokemon as evolving
-    samePokemon.forEach(pokemon => {
-      this.markedForEvolution[pokemon.id] = true;
-    });
-
-    // play a flashing animation for a bit
-    // not sure how to use tweens to get a flashing trigger of the outline
-    // so this just manually creates one using window.setTimeout
-    let timeout = 350;
-    let flashAnimation: number;
-    const toggleAnim = () => {
-      samePokemon.forEach(pokemon => pokemon.toggleOutline());
-      timeout *= 0.75;
-      flashAnimation = window.setTimeout(toggleAnim, timeout);
-    };
-    toggleAnim();
-
-    window.setTimeout(() => {
-      // end animation
-      window.clearInterval(flashAnimation);
-      // delete old Pokemon
-      samePokemon.forEach(pokemon => {
-        this.markedForEvolution[pokemon.id] = false;
-        this.removePokemon(pokemon);
-      });
-      // add new one
-      const evo = new PokemonObject({
-        scene: this,
-        x: 0,
-        y: 0,
-        name: evolutionName,
-        side: 'player',
-      });
-      this.add.existing(evo);
-      this.setPokemonAtLocation(evoLocation, evo);
-      // play animation to make it super clear
-      evo.setScale(1.5, 1.5);
-      this.add.tween({
-        targets: [evo],
-        scaleX: 1,
-        scaleY: 1,
-        ease: Phaser.Math.Easing.Expo.InOut,
-        duration: 500,
-        onComplete: () => {
-          this.applyEvolutions(evo);
-        },
-      });
-    }, 1000);
+    this.player.setPokemonAtLocation(toLocation, fromPokemon);
+    this.player.setPokemonAtLocation(fromLocation, swapTarget);
   }
 
   /**
@@ -669,12 +417,12 @@ export class GameScene extends Phaser.Scene {
       return false;
     }
 
-    if (!this.canAddPokemonToSideboard()) {
+    if (!this.player.canAddPokemonToSideboard()) {
       return false;
     }
 
     player.gold -= pokemonData[pokemonName].tier;
-    this.addPokemonToSideboard(pokemonName);
+    this.player.addPokemonToSideboard(pokemonName);
     return true;
   }
 
@@ -693,7 +441,7 @@ export class GameScene extends Phaser.Scene {
       player.gold += pokemon.basePokemon.tier + 4;
     }
 
-    this.removePokemon(pokemon);
+    this.player.removePokemon(pokemon);
   }
 
   /**
@@ -704,7 +452,7 @@ export class GameScene extends Phaser.Scene {
    */
   generateEnemyBoard() {
     // calculate total cost of player board
-    const value = flatten(this.mainboard)
+    const value = flatten(this.player.mainboard)
       .filter(isDefined)
       .reduce(
         (total, pokemon) =>


### PR DESCRIPTION
This commit refactors the `GameScene` so it can support multiple players.
- Boards/sideboards are now stored inside the `Player` object, and all manipulation of those is done via class methods.
- The `GameScene` creates and tracks multiple `Player` objects, with one specified as the human player.