### PR TITLE
Swap timers to use Phaser Time

### DIFF
--- a/src/core/moves/cotton-guard.ts
+++ b/src/core/moves/cotton-guard.ts
@@ -47,14 +47,17 @@ const move = {
       onComplete();
 
       // end animation when status is over
-      setTimeout(() => {
-        if (cotton.active) {
-          cotton.play('cotton-guard-end');
-          cotton.once(Phaser.Animations.Events.ANIMATION_COMPLETE, () => {
-            cotton.destroy();
-          });
-        }
-      }, DURATION);
+      scene.time.addEvent({
+        callback: () => {
+          if (cotton.active) {
+            cotton.play('cotton-guard-end');
+            cotton.once(Phaser.Animations.Events.ANIMATION_COMPLETE, () => {
+              cotton.destroy();
+            });
+          }
+        },
+        delay: DURATION,
+      });
     });
   },
 } as const;

--- a/src/core/moves/dark-void.ts
+++ b/src/core/moves/dark-void.ts
@@ -49,19 +49,20 @@ const move = {
         // todo: add attack graphics
         targets.forEach(target => target.addStatus('sleep', 4000));
         // apply damage every second for 4 seconds
-        const damageEffect = window.setInterval(() => {
-          targets.forEach(target => {
-            const damage = calculateDamage(user, target, {
-              damage: target.maxHP / 10,
-              defenseStat: 'specDefense',
+        scene.time.addEvent({
+          callback: () => {
+            targets.forEach(target => {
+              const damage = calculateDamage(user, target, {
+                damage: target.maxHP / 10,
+                defenseStat: 'specDefense',
+              });
+              scene.causeDamage(user, target, damage, { isAOE: true });
+              user.heal(damage / 2);
             });
-            scene.causeDamage(user, target, damage, { isAOE: true });
-            user.heal(damage / 2);
-          });
-        }, 1000);
-        window.setTimeout(() => {
-          window.clearInterval(damageEffect);
-        }, 4000);
+          },
+          delay: 1000,
+          repeat: 4,
+        });
       },
     });
   },

--- a/src/core/moves/dragon-rush.ts
+++ b/src/core/moves/dragon-rush.ts
@@ -87,24 +87,27 @@ const move = {
     });
 
     // wait through the first bit of the dragon rush animation
-    setTimeout(() => {
-      // if target coord is somehow occupied now, don't move
-      // TODO: retarget
-      if (board[targetCoords.x][targetCoords.y] !== undefined) {
-        onComplete();
-        return;
-      }
-      scene.movePokemon(userCoords, targetCoords, onComplete);
-      const damage = this.damage[user.basePokemon.stage - 1];
-      this.getAOE(targetCoords, userCoords).forEach(({ x, y }) => {
-        const thisTarget = board[x][y];
-        if (thisTarget?.side === getOppositeSide(user.side)) {
-          scene.causeDamage(user, thisTarget, damage, { isAOE: true });
+    scene.time.addEvent({
+      callback: () => {
+        // if target coord is somehow occupied now, don't move
+        // TODO: retarget
+        if (board[targetCoords.x][targetCoords.y] !== undefined) {
+          onComplete();
+          return;
         }
-      });
-      // reset target after movement
-      user.currentTarget = undefined;
-    }, 250);
+        scene.movePokemon(userCoords, targetCoords, onComplete);
+        const damage = this.damage[user.basePokemon.stage - 1];
+        this.getAOE(targetCoords, userCoords).forEach(({ x, y }) => {
+          const thisTarget = board[x][y];
+          if (thisTarget?.side === getOppositeSide(user.side)) {
+            scene.causeDamage(user, thisTarget, damage, { isAOE: true });
+          }
+        });
+        // reset target after movement
+        user.currentTarget = undefined;
+      },
+      delay: 250,
+    });
   },
 } as const;
 

--- a/src/core/moves/egg-barrage.ts
+++ b/src/core/moves/egg-barrage.ts
@@ -88,16 +88,17 @@ const move = {
       );
     };
 
-    const eggFiringInterval = window.setInterval(() => {
-      shootEgg();
-    }, 200);
+    scene.time.addEvent({
+      callback: () => shootEgg(),
+      delay: 200,
+      repeat: 5,
+    });
     Tweens.spin(scene, {
       targets: [user],
       height: 25,
       width: 25,
       duration: 1000,
       onComplete: () => {
-        window.clearInterval(eggFiringInterval);
         onComplete();
       },
     });

--- a/src/core/moves/fury-cutter.ts
+++ b/src/core/moves/fury-cutter.ts
@@ -42,15 +42,17 @@ const move = {
             // animation: play a number of slashes equal to the number of attacks up to now
             const event = scene.time.addEvent({
               callback: () => {
-                if (event.repeatCount >= user.consecutiveAttacks) {
+                // at the end of the loop, clean up
+                if (event.repeatCount === 0) {
                   animationArr.forEach(sprite => sprite.destroy());
+                } else {
+                  animationArr.push(
+                    scene.add
+                      .sprite(target.x, target.y, 'fury-cutter')
+                      .play('fury-cutter')
+                      .setFlipX(event.repeatCount % 2 === 0)
+                  );
                 }
-                animationArr.push(
-                  scene.add
-                    .sprite(target.x, target.y, 'fury-cutter')
-                    .play('fury-cutter')
-                    .setFlipX(event.repeatCount % 2 === 0)
-                );
               },
               delay: 100,
               // repeat once more than necessary to clean up

--- a/src/core/moves/fury-cutter.ts
+++ b/src/core/moves/fury-cutter.ts
@@ -40,24 +40,22 @@ const move = {
             user.consecutiveAttacks++;
             const animationArr: Phaser.GameObjects.Sprite[] = [];
             // animation: play a number of slashes equal to the number of attacks up to now
-            const playAnimation = (count: number) => {
-              animationArr.push(
-                scene.add
-                  .sprite(target.x, target.y, 'fury-cutter')
-                  .play('fury-cutter')
-                  .setFlipX(count % 2 === 0)
-              );
-              if (count > 0) {
-                // if there are still attacks to be performed do it.
-                window.setTimeout(() => playAnimation(count - 1), 100);
-              } else {
-                // otherwise, clean up
-                window.setTimeout(() => {
+            const event = scene.time.addEvent({
+              callback: () => {
+                if (event.repeatCount >= user.consecutiveAttacks) {
                   animationArr.forEach(sprite => sprite.destroy());
-                }, 200);
-              }
-            };
-            playAnimation(user.consecutiveAttacks);
+                }
+                animationArr.push(
+                  scene.add
+                    .sprite(target.x, target.y, 'fury-cutter')
+                    .play('fury-cutter')
+                    .setFlipX(event.repeatCount % 2 === 0)
+                );
+              },
+              delay: 100,
+              // repeat once more than necessary to clean up
+              repeat: user.consecutiveAttacks + 1,
+            });
             const damage = calculateDamage(user, target, {
               // damage increases by 50% each strike
               damage:

--- a/src/core/moves/meteor-mash.ts
+++ b/src/core/moves/meteor-mash.ts
@@ -102,18 +102,14 @@ const move = {
               target.addStatus('paralyse', 4000);
             }
 
-            scene.time.addEvent({
-              callback: () => {
-                scene.add.tween({
-                  targets: [user],
-                  duration: 500,
-                  ...originalCoords,
-                  onComplete: () => {
-                    onComplete();
-                  },
-                });
-              },
+            scene.add.tween({
+              targets: [user],
+              duration: 500,
               delay: 250,
+              ...originalCoords,
+              onComplete: () => {
+                onComplete();
+              },
             });
           },
         });

--- a/src/core/moves/meteor-mash.ts
+++ b/src/core/moves/meteor-mash.ts
@@ -102,16 +102,19 @@ const move = {
               target.addStatus('paralyse', 4000);
             }
 
-            setTimeout(() => {
-              scene.add.tween({
-                targets: [user],
-                duration: 500,
-                ...originalCoords,
-                onComplete: () => {
-                  onComplete();
-                },
-              });
-            }, 250);
+            scene.time.addEvent({
+              callback: () => {
+                scene.add.tween({
+                  targets: [user],
+                  duration: 500,
+                  ...originalCoords,
+                  onComplete: () => {
+                    onComplete();
+                  },
+                });
+              },
+              delay: 250,
+            });
           },
         });
       },

--- a/src/core/moves/shell-trap.ts
+++ b/src/core/moves/shell-trap.ts
@@ -91,10 +91,13 @@ const move = {
 
         user.on(PokemonObject.Events.Damage, damageProc);
 
-        setTimeout(() => {
-          user.setTint();
-          user.removeListener(PokemonObject.Events.Damage, damageProc);
-        }, DURATION);
+        scene.time.addEvent({
+          callback: () => {
+            user.setTint();
+            user.removeListener(PokemonObject.Events.Damage, damageProc);
+          },
+          delay: DURATION,
+        });
       },
     });
   },

--- a/src/core/moves/stone-edge.ts
+++ b/src/core/moves/stone-edge.ts
@@ -53,31 +53,33 @@ const move = {
         stones
           .play('stone-edge-shoot')
           .once(Phaser.Animations.Events.ANIMATION_COMPLETE, () => {
-            console.log('second');
             onComplete();
             stones.destroy();
           });
 
         // deal damage halfway through the shoot part of the animation
         // when the rocks pass through the targets
-        setTimeout(() => {
-          const targets = this.getAOE(targetCoords, userCoords)
-            .map(coords => board[coords.x]?.[coords.y])
-            .filter(isDefined)
-            .filter(pokemon => pokemon.side === getOppositeSide(user.side));
+        scene.time.addEvent({
+          callback: () => {
+            const targets = this.getAOE(targetCoords, userCoords)
+              .map(coords => board[coords.x]?.[coords.y])
+              .filter(isDefined)
+              .filter(pokemon => pokemon.side === getOppositeSide(user.side));
 
-          const rawBaseDamage = this.damage[user.basePokemon.stage - 1];
-          // deal more damage if there's only one target
-          const realBaseDamage =
-            targets.length === 1 ? rawBaseDamage * 1.5 : rawBaseDamage;
-          targets.forEach(pokemon => {
-            const damage = calculateDamage(user, pokemon, {
-              damage: realBaseDamage,
-              defenseStat: 'defense',
+            const rawBaseDamage = this.damage[user.basePokemon.stage - 1];
+            // deal more damage if there's only one target
+            const realBaseDamage =
+              targets.length === 1 ? rawBaseDamage * 1.5 : rawBaseDamage;
+            targets.forEach(pokemon => {
+              const damage = calculateDamage(user, pokemon, {
+                damage: realBaseDamage,
+                defenseStat: 'defense',
+              });
+              scene.causeDamage(user, pokemon, damage, { isAOE: true });
             });
-            scene.causeDamage(user, pokemon, damage, { isAOE: true });
-          });
-        }, animations['stone-edge-shoot'].duration / 2);
+          },
+          delay: animations['stone-edge-shoot'].duration / 2,
+        });
       });
   },
 } as const;

--- a/src/core/moves/thunder-wave.ts
+++ b/src/core/moves/thunder-wave.ts
@@ -13,17 +13,19 @@ const move = {
       targets: [user],
       onComplete: () => {
         const img = scene.add.image(target.x, target.y, 'thunder-wave');
-        const flashAnimation = window.setInterval(
-          () => img.setVisible(!img.visible),
-          200
-        );
-        window.setTimeout(() => {
-          clearInterval(flashAnimation);
-          img.destroy();
+        const timer = scene.time.addEvent({
+          callback: () => {
+            // play flicker "animation"
+            img.setVisible(!img.visible);
 
-          target.addStatus('paralyse', 4000);
-          onComplete();
-        }, 600);
+            // if this is the end of the animation, apply status
+            if (timer.repeatCount >= timer.repeat) {
+              target.addStatus('paralyse', 4000);
+            }
+          },
+          delay: 200,
+          repeat: 4,
+        });
       },
     });
   },

--- a/src/core/moves/thunder-wave.ts
+++ b/src/core/moves/thunder-wave.ts
@@ -19,13 +19,14 @@ const move = {
             img.setVisible(!img.visible);
 
             // if this is the end of the animation, apply status
-            if (timer.repeatCount >= timer.repeat) {
+            if (timer.repeatCount === 0) {
               target.addStatus('paralyse', 4000);
             }
           },
           delay: 200,
           repeat: 4,
         });
+        onComplete();
       },
     });
   },

--- a/src/core/moves/tri-attack.ts
+++ b/src/core/moves/tri-attack.ts
@@ -91,51 +91,65 @@ const move = {
             }
 
             // explosion 2: 9 squares
-            window.setTimeout(() => {
-              explosions.play('tri-attack-electric');
-              scene.add.tween({
-                targets: [explosions],
-                scaleX: 2,
-                scaleY: 2,
-                duration: 150,
-                ease: Phaser.Math.Easing.Quadratic.In,
-                onComplete: () => {
-                  this.getAOE(targetCoords).forEach(({ x, y }) => {
-                    const thisTarget = board[x]?.[y];
-                    if (thisTarget?.side === getOppositeSide(user.side)) {
-                      scene.causeDamage(user, thisTarget, damage, {
-                        isAOE: true,
-                      });
-                    }
-                  });
-                },
-              });
-            }, animations['tri-attack-fire'].duration);
+            scene.time.addEvent({
+              callback: () => {
+                explosions.play('tri-attack-electric');
+                scene.add.tween({
+                  targets: [explosions],
+                  scaleX: 2,
+                  scaleY: 2,
+                  duration: 150,
+                  ease: Phaser.Math.Easing.Quadratic.In,
+                  onComplete: () => {
+                    this.getAOE(targetCoords).forEach(({ x, y }) => {
+                      const thisTarget = board[x]?.[y];
+                      if (thisTarget?.side === getOppositeSide(user.side)) {
+                        scene.causeDamage(user, thisTarget, damage, {
+                          isAOE: true,
+                        });
+                      }
+                    });
+                  },
+                });
+              },
+              delay: animations['tri-attack-fire'].duration,
+            });
 
             // explosion 3: also 9 squares
-            window.setTimeout(() => {
-              explosions.play('tri-attack-ice');
-              scene.add.tween({
-                targets: [explosions],
-                scaleX: 3,
-                scaleY: 3,
-                duration: 150,
-                ease: Phaser.Math.Easing.Quadratic.In,
-                onComplete: () => {
-                  this.getAOE(targetCoords).forEach(({ x, y }) => {
-                    const thisTarget = board[x]?.[y];
-                    if (thisTarget?.side === getOppositeSide(user.side)) {
-                      scene.causeDamage(user, thisTarget, damage, {
-                        isAOE: true,
-                      });
-                    }
-                  });
-                },
-              });
-            }, animations['tri-attack-fire'].duration + animations['tri-attack-electric'].duration);
-            window.setTimeout(() => {
-              explosions.destroy();
-            }, animations['tri-attack-fire'].duration + animations['tri-attack-electric'].duration + animations['tri-attack-ice'].duration);
+            scene.time.addEvent({
+              callback: () => {
+                explosions.play('tri-attack-ice');
+                scene.add.tween({
+                  targets: [explosions],
+                  scaleX: 3,
+                  scaleY: 3,
+                  duration: 150,
+                  ease: Phaser.Math.Easing.Quadratic.In,
+                  onComplete: () => {
+                    this.getAOE(targetCoords).forEach(({ x, y }) => {
+                      const thisTarget = board[x]?.[y];
+                      if (thisTarget?.side === getOppositeSide(user.side)) {
+                        scene.causeDamage(user, thisTarget, damage, {
+                          isAOE: true,
+                        });
+                      }
+                    });
+                  },
+                });
+              },
+              delay:
+                animations['tri-attack-fire'].duration +
+                animations['tri-attack-electric'].duration,
+            });
+            scene.time.addEvent({
+              callback: () => {
+                explosions.destroy();
+              },
+              delay:
+                animations['tri-attack-fire'].duration +
+                animations['tri-attack-electric'].duration +
+                animations['tri-attack-ice'].duration,
+            });
           },
         });
       },

--- a/src/core/moves/zap-cannon.ts
+++ b/src/core/moves/zap-cannon.ts
@@ -70,7 +70,10 @@ const move = {
           .sprite(user.x, user.y, 'thunder')
           .setOrigin(0, 0.5)
           .setRotation(getAngle(user, targettedLocation))
-          .play('thunder');
+          .play('thunder')
+          .on(Phaser.Animations.Events.ANIMATION_COMPLETE, () => {
+            thunder.destroy();
+          });
         // scale length of beam to target distance
         // if longer than the base sprite
         thunder.displayWidth = Math.max(
@@ -82,24 +85,24 @@ const move = {
             targettedLocation.y
           )
         );
-        setTimeout(() => {
-          this.getAOE(userCoords, targetCoords).forEach(({ x, y }) => {
-            const pokemon = board[x]?.[y];
-            if (!pokemon) {
-              return;
-            }
-            if (pokemon.side !== user.side) {
-              const damage = calculateDamage(user, pokemon, {
-                damage: this.damage[user.basePokemon.stage - 1],
-                defenseStat: this.defenseStat,
-              });
-              scene.causeDamage(user, pokemon, damage, { isAOE: true });
-            }
-          });
-        }, animations.thunder.duration * 0.5);
-        setTimeout(() => {
-          thunder.destroy();
-        }, animations.thunder.duration);
+        scene.time.addEvent({
+          callback: () => {
+            this.getAOE(userCoords, targetCoords).forEach(({ x, y }) => {
+              const pokemon = board[x]?.[y];
+              if (!pokemon) {
+                return;
+              }
+              if (pokemon.side !== user.side) {
+                const damage = calculateDamage(user, pokemon, {
+                  damage: this.damage[user.basePokemon.stage - 1],
+                  defenseStat: this.defenseStat,
+                });
+                scene.causeDamage(user, pokemon, damage, { isAOE: true });
+              }
+            });
+          },
+          delay: animations.thunder.duration * 0.5,
+        });
 
         user.setScale(1, 1);
         onComplete();

--- a/src/objects/player.object.ts
+++ b/src/objects/player.object.ts
@@ -222,47 +222,51 @@ export class Player extends Phaser.GameObjects.GameObject {
 
     // play a flashing animation for a bit
     // not sure how to use tweens to get a flashing trigger of the outline
-    // so this just manually creates one using window.setTimeout
-    let timeout = 350;
-    let flashAnimation: number;
-    const toggleAnim = () => {
-      samePokemon.forEach(pokemon => pokemon.toggleOutline());
-      timeout *= 0.75;
-      flashAnimation = window.setTimeout(toggleAnim, timeout);
-    };
-    toggleAnim();
+    // so this just manually creates one using timers
+    const flashTimer = this.scene.time.addEvent({
+      callback: () => {
+        samePokemon.forEach(pokemon => pokemon.toggleOutline());
+        // and make it faster
+        flashTimer.timeScale *= 1.5;
+      },
+      delay: 350,
+      loop: true,
+    });
 
-    window.setTimeout(() => {
-      // end animation
-      window.clearInterval(flashAnimation);
-      // delete old Pokemon
-      samePokemon.forEach(pokemon => {
-        this.markedForEvolution[pokemon.id] = false;
-        this.removePokemon(pokemon);
-      });
-      // add new one
-      const evo = new PokemonObject({
-        scene: this.scene,
-        x: 0,
-        y: 0,
-        name: evolutionName,
-        side: 'player',
-      });
-      this.scene.add.existing(evo);
-      this.setPokemonAtLocation(evoLocation, evo);
-      // play animation to make it super clear
-      evo.setScale(1.5, 1.5);
-      this.scene.add.tween({
-        targets: [evo],
-        scaleX: 1,
-        scaleY: 1,
-        ease: Phaser.Math.Easing.Expo.InOut,
-        duration: 500,
-        onComplete: () => {
-          this.applyEvolutions(evo);
-        },
-      });
-    }, 1000);
+    this.scene.time.addEvent({
+      callback: () => {
+        // end animation
+        flashTimer.remove();
+        // delete old Pokemon
+        samePokemon.forEach(pokemon => {
+          this.markedForEvolution[pokemon.id] = false;
+          this.removePokemon(pokemon);
+        });
+        // add new one
+        const evo = new PokemonObject({
+          scene: this.scene,
+          x: 0,
+          y: 0,
+          name: evolutionName,
+          side: 'player',
+        });
+        this.scene.add.existing(evo);
+        this.setPokemonAtLocation(evoLocation, evo);
+        // play animation to make it super clear
+        evo.setScale(1.5, 1.5);
+        this.scene.add.tween({
+          targets: [evo],
+          scaleX: 1,
+          scaleY: 1,
+          ease: Phaser.Math.Easing.Expo.InOut,
+          duration: 500,
+          onComplete: () => {
+            this.applyEvolutions(evo);
+          },
+        });
+      },
+      delay: 1000,
+    });
   }
 
   removePokemon(pokemon: PokemonObject) {

--- a/src/scenes/game/combat/combat.scene.ts
+++ b/src/scenes/game/combat/combat.scene.ts
@@ -300,7 +300,10 @@ export class CombatScene extends Scene {
   setTurn(pokemon: PokemonObject) {
     const delay = getTurnDelay(pokemon.basePokemon);
     pokemon.updateStatuses(delay);
-    setTimeout(() => this.takeTurn(pokemon), delay);
+    this.time.addEvent({
+      callback: () => this.takeTurn(pokemon),
+      delay,
+    });
   }
 
   /**

--- a/src/scenes/game/game.scene.ts
+++ b/src/scenes/game/game.scene.ts
@@ -372,9 +372,12 @@ export class GameScene extends Phaser.Scene {
             })
             .setDepth(200)
             .setOrigin(0.5, 0.5);
-          setTimeout(() => {
-            this.scene.start(MenuScene.KEY);
-          }, 2000);
+          this.time.addEvent({
+            callback: () => {
+              this.scene.start(MenuScene.KEY);
+            },
+            delay: 2000,
+          });
         }
         this.startDowntime();
       },

--- a/src/scenes/menu.scene.ts
+++ b/src/scenes/menu.scene.ts
@@ -57,9 +57,12 @@ export class MenuScene extends Scene {
       .on(
         Phaser.GameObjects.Events.DESTROY,
         () => {
-          window.setTimeout(() => {
-            this.addTitlePokemon();
-          }, 1000);
+          this.time.addEvent({
+            callback: () => {
+              this.addTitlePokemon();
+            },
+            delay: 1000,
+          });
         },
         this
       );


### PR DESCRIPTION
... instead of setTimeout/setInterval.

Phaser has built-in Time (https://photonstorm.github.io/phaser3-docs/Phaser.Time.TimerEvent.html) functionality which handles timer events. Unlike browser timers, these are hooked into the Scenes, are automatically culled when Scenes end, and can be scaled faster/slower. They also have some nice utilities attached like the ability to repeat a set amount of times - much easier to use than recursive `setTimeout` or `setInterval` with a cancel.

This commit swaps all the setTimeouts in the codebase (aside from a few in Scenes where they are used after the scene is paused) to use TimerEvents instead.

tbh i didn't test everything but whatever lol