### PR TITLE
Make click events only apply on left click

### DIFF
--- a/src/objects/button.object.ts
+++ b/src/objects/button.object.ts
@@ -1,6 +1,10 @@
 import { titleStyle } from './text.helpers';
 
 export class Button extends Phaser.GameObjects.Text {
+  static Events = {
+    CLICK: 'buttonClick',
+  };
+
   constructor(scene: Phaser.Scene, x: number, y: number, text: string) {
     super(scene, x, y, text.toUpperCase(), {
       ...titleStyle,
@@ -12,10 +16,16 @@ export class Button extends Phaser.GameObjects.Text {
     this.setOrigin(0.5, 0.5);
     this.setInteractive({ useHandCursor: true });
 
-    this.on(Phaser.Input.Events.POINTER_OVER, () =>
-      this.setStyle({ fontStyle: 'bold' })
-    ).on(Phaser.Input.Events.POINTER_OUT, () =>
-      this.setStyle({ fontStyle: 'normal' })
-    );
+    this.on(Phaser.Input.Events.POINTER_OVER, () => {
+      this.setStyle({ fontStyle: 'bold' });
+    })
+      .on(Phaser.Input.Events.POINTER_OUT, () => {
+        this.setStyle({ fontStyle: 'normal' });
+      })
+      .on(Phaser.Input.Events.POINTER_DOWN, (event: Phaser.Input.Pointer) => {
+        if (event.leftButtonDown()) {
+          this.emit(Button.Events.CLICK);
+        }
+      });
   }
 }

--- a/src/scenes/game/game.scene.ts
+++ b/src/scenes/game/game.scene.ts
@@ -264,10 +264,12 @@ export class GameScene extends Phaser.Scene {
     this.input.on(
       Phaser.Input.Events.POINTER_DOWN,
       (event: Phaser.Input.Pointer) => {
-        if (!this.selectedPokemon) {
-          this.selectPokemon({ x: event.downX, y: event.downY });
-        } else {
-          this.movePokemon({ x: event.downX, y: event.downY });
+        if (event.leftButtonDown()) {
+          if (!this.selectedPokemon) {
+            this.selectPokemon({ x: event.downX, y: event.downY });
+          } else {
+            this.movePokemon({ x: event.downX, y: event.downY });
+          }
         }
       }
     );
@@ -277,9 +279,7 @@ export class GameScene extends Phaser.Scene {
     });
 
     this.shopButton = this.add.existing(new Button(this, 400, 580, 'Shop'));
-    this.shopButton.on(Phaser.Input.Events.GAMEOBJECT_POINTER_DOWN, () =>
-      this.toggleShop()
-    );
+    this.shopButton.on(Button.Events.CLICK, () => this.toggleShop());
 
     this.sellArea = this.add
       .rectangle(
@@ -292,12 +292,16 @@ export class GameScene extends Phaser.Scene {
       )
       .setVisible(false);
 
-    this.sellArea.setInteractive().on('pointerdown', () => {
-      this.sellPokemon(this.player, this.selectedPokemon as PokemonObject);
-    });
+    this.sellArea
+      .setInteractive()
+      .on(Phaser.Input.Events.POINTER_DOWN, (event: Phaser.Input.Pointer) => {
+        if (event.leftButtonDown()) {
+          this.sellPokemon(this.player, this.selectedPokemon as PokemonObject);
+        }
+      });
 
     this.nextRoundButton = new Button(this, SIDEBOARD_X, 450, 'Next Round');
-    this.nextRoundButton.on(Phaser.Input.Events.GAMEOBJECT_POINTER_DOWN, () => {
+    this.nextRoundButton.on(Button.Events.CLICK, () => {
       this.nextRoundButton.destroy();
       this.startCombat();
     });
@@ -420,7 +424,7 @@ export class GameScene extends Phaser.Scene {
     this.input.enabled = true;
 
     this.nextRoundButton = new Button(this, SIDEBOARD_X, 450, 'Next Round');
-    this.nextRoundButton.on(Phaser.Input.Events.GAMEOBJECT_POINTER_DOWN, () => {
+    this.nextRoundButton.on(Button.Events.CLICK, () => {
       this.nextRoundButton.destroy();
       this.startCombat();
     });

--- a/src/scenes/game/shop.scene.ts
+++ b/src/scenes/game/shop.scene.ts
@@ -36,7 +36,7 @@ export class ShopScene extends Phaser.Scene {
       new Button(this, this.centre.x, this.centre.y + 60, 'Reroll')
     );
 
-    rerollButton.on(Phaser.Input.Events.GAMEOBJECT_POINTER_DOWN, () => {
+    rerollButton.on(Button.Events.CLICK, () => {
       // maybe not best to be handled by the shop
       if (this.player.gold >= REROLL_COST) {
         this.player.gold -= REROLL_COST;
@@ -49,18 +49,20 @@ export class ShopScene extends Phaser.Scene {
     this.input.on(
       Phaser.Input.Events.POINTER_DOWN,
       (event: Phaser.Input.Pointer) => {
-        const i = this.getShopIndexForCoordinates({
-          x: event.downX,
-          y: event.downY,
-        });
-        if (i !== undefined) {
-          if (this.pokemonForSale[i] === undefined) {
-            console.log('No pokemon here');
-            return;
-          }
+        if (event.leftButtonDown()) {
+          const i = this.getShopIndexForCoordinates({
+            x: event.downX,
+            y: event.downY,
+          });
+          if (i !== undefined) {
+            if (this.pokemonForSale[i] === undefined) {
+              console.log('No pokemon here');
+              return;
+            }
 
-          if (!this.buyPokemon(i)) {
-            console.log('Not enough gold to buy this pokemon');
+            if (!this.buyPokemon(i)) {
+              console.log('Not enough gold to buy this pokemon');
+            }
           }
         }
       }

--- a/src/scenes/menu.scene.ts
+++ b/src/scenes/menu.scene.ts
@@ -29,7 +29,7 @@ export class MenuScene extends Scene {
     this.startButton = this.add.existing(
       new Button(this, 400, 500, 'Single Player')
     );
-    this.startButton.on(Phaser.Input.Events.GAMEOBJECT_POINTER_DOWN, () =>
+    this.startButton.on(Button.Events.CLICK, () =>
       this.scene.start(GameScene.KEY)
     );
   }


### PR DESCRIPTION
Phaser's default `POINTER_DOWN` event applies to all mouse clicks, and there isn't a specific event for left click. As such, all clicks (eg. buying/selling Pokemon, clicking buttons) can currently occur on any click.

This commit updates the button and all other clickable objects to check for the left button. I will need right click for the Pokemon info card.

I hope this doesn't break touch devices xd