### PR TITLE
Perf: Reuse synergy marker objects

### DIFF
--- a/src/objects/player.object.ts
+++ b/src/objects/player.object.ts
@@ -37,7 +37,7 @@ export class Player extends Phaser.GameObjects.GameObject {
   sideboard: (PokemonObject | undefined)[] = Array(8).fill(undefined);
 
   synergies: { category: Category; count: number }[] = [];
-  synergyIcons: SynergyMarker[] = [];
+  synergyMarkers: { [k in Category]?: SynergyMarker } = {};
 
   constructor(
     scene: GameScene,
@@ -338,21 +338,25 @@ export class Player extends Phaser.GameObjects.GameObject {
         }
         return b.category > a.category ? -1 : 1;
       });
-    // clean up old icons
-    this.synergyIcons.forEach(icon => icon.destroy());
-    // and add new ones
-    this.synergyIcons = this.synergies.map(
-      ({ category, count }, index) =>
-        this.scene.add.existing(
-          new SynergyMarker(
-            this.scene,
-            40,
-            170 + index * SynergyMarker.height,
-            category as Category,
-            count
-          )
-        ) as SynergyMarker
-    );
+
+    // hide all synergy markers
+    Object.values(this.synergyMarkers).forEach(marker => {
+      marker.setVisible(false).setActive(false);
+    });
+    // then show and reposition the active ones
+    this.synergies.slice(0, 9).forEach((synergy, index) => {
+      if (!this.synergyMarkers[synergy.category]) {
+        // if we haven't created the marker yet, create it now
+        this.synergyMarkers[synergy.category] = this.scene.add.existing(
+          new SynergyMarker(this.scene, 0, 0, synergy.category, synergy.count)
+        );
+      }
+      this.synergyMarkers[synergy.category]
+        ?.setActive(true)
+        .setVisible(true)
+        .setPosition(40, 170 + index * SynergyMarker.height)
+        .setCount(synergy.count);
+    });
   }
 
   canAddPokemonToMainboard() {

--- a/src/objects/synergy-marker.object.ts
+++ b/src/objects/synergy-marker.object.ts
@@ -28,41 +28,30 @@ export class SynergyMarker extends Phaser.GameObjects.Sprite {
     scene: Phaser.Scene,
     x: number,
     y: number,
-    category: Category,
+    public category: Category,
     count: number
   ) {
     super(scene, x, y, category);
     this.setDisplaySize(100, 22);
     this.setOrigin(0);
 
-    const { description, thresholds } = synergyData[category];
-
-    const tier = getSynergyTier(thresholds, count);
-    // tier starts at 1, so next threshold is just the entry after
-    // tier can be `thresholds.length`, in which case it would be undefined and should default to max
-    const nextThreshold = thresholds[tier] ?? thresholds[thresholds.length - 1];
-
     this.thresholdText = scene.add
-      .text(x + this.displayWidth + 4, y + 4, `${count}/${nextThreshold}`, {
+      .text(x + this.displayWidth + 4, y + 4, ``, {
         ...titleStyle,
         color: '#000',
       })
       .setOrigin(0);
     // background covers the type + text and grows in size based on tier
+    // styles are applied in `setCount()`
     this.background = scene.add
-      .rectangle(
-        this.x - tier,
-        this.y - tier,
-        this.displayWidth + this.thresholdText.displayWidth + 6 + tier * 2,
-        this.displayHeight + tier * 2,
-        this.colors[tier]
-      )
+      .rectangle()
       .setOrigin(0)
       .setDepth(-1);
+    this.setCount(count);
 
     // hover text showing the description
     this.descriptionText = scene.add
-      .text(0, 0, description, {
+      .text(0, 0, synergyData[category].description, {
         ...defaultStyle,
         color: '#FFF',
         backgroundColor: '#5F7D99',
@@ -96,5 +85,38 @@ export class SynergyMarker extends Phaser.GameObjects.Sprite {
       this.background.destroy();
     }
     super.destroy();
+  }
+
+  setVisible(visible: boolean): this {
+    super.setVisible(visible);
+    this.thresholdText.setVisible(visible);
+    this.background.setVisible(visible);
+    return this;
+  }
+
+  setActive(active: boolean): this {
+    super.setActive(active);
+    this.thresholdText.setActive(active);
+    this.background.setActive(active);
+    return this;
+  }
+
+  setCount(count: number) {
+    const { thresholds } = synergyData[this.category];
+    const tier = getSynergyTier(thresholds, count);
+    // tier starts at 1, so next threshold is just the entry after
+    // tier can be `thresholds.length`, in which case it would be undefined and should default to max
+    const nextThreshold = thresholds[tier] ?? thresholds[thresholds.length - 1];
+
+    this.thresholdText
+      .setPosition(this.x + this.displayWidth + 4, this.y + 4)
+      .setText(`${count}/${nextThreshold}`);
+    this.background
+      .setPosition(this.x - tier, this.y - tier)
+      .setSize(
+        this.displayWidth + this.thresholdText.displayWidth + 6 + tier * 2,
+        this.displayHeight + tier * 2
+      )
+      .setFillStyle(this.colors[tier]);
   }
 }

--- a/src/scenes/game/game.scene.ts
+++ b/src/scenes/game/game.scene.ts
@@ -237,8 +237,8 @@ export class GameScene extends Phaser.Scene {
       .setFontSize(20)
       .setOrigin(0.5, 0);
 
-    this.players = ['You', ...getRandomNames(7)].map(
-      (name, index) => new Player(this, name, 620, 100 + 30 * index)
+    this.players = ['You', ...getRandomNames(7)].map((name, index) =>
+      this.add.existing(new Player(this, name, 620, 100 + 30 * index))
     );
     // players[0] is always the human player
     [this.player] = this.players;


### PR DESCRIPTION
The current synergy display logic destroys/reconstructs them every time they need to be updated. This is quite expensive, as construction requires loading in images. When there are lots of synergies (5-10+), this can cause a few frames to be dropped when moving Pokemon on the board.

This commit updates the logic to render them on-demand and hide them when they're not in use. It makes the necessary refactors to SynergyMarker so that markers can have their visibility toggled.