### PR TITLE
Implement viewing other players' boards

### DIFF
--- a/src/objects/player.object.ts
+++ b/src/objects/player.object.ts
@@ -71,7 +71,9 @@ export class Player extends Phaser.GameObjects.GameObject {
   }
 
   update() {
-    this.nameInList.setText(`${this.playerName} - ${this.hp}`);
+    this.nameInList.setText(
+      `${this.playerName} - ${this.hp} ${this.visible ? '👁️' : ''}`
+    );
   }
 
   updatePosition(x: number, y: number) {

--- a/src/objects/player.object.ts
+++ b/src/objects/player.object.ts
@@ -18,7 +18,7 @@ import { defaultStyle } from './text.helpers';
 
 const MAX_MAINBOARD_POKEMON = 6;
 
-export class Player extends Phaser.GameObjects.GameObject {
+export class Player extends Phaser.GameObjects.Group {
   hp = 100;
   gold = 20;
   /** Consecutive win/loss streak */
@@ -51,7 +51,8 @@ export class Player extends Phaser.GameObjects.GameObject {
     private readonly pool: ShopPool,
     private visible = false
   ) {
-    super(scene, 'player');
+    super(scene);
+    super.setVisible(visible);
 
     // not part of group - always visible
     // TODO: move to game scene?
@@ -328,7 +329,7 @@ export class Player extends Phaser.GameObjects.GameObject {
       getSideboardLocationForCoordinates(pokemon);
     if (!location) {
       // just destroy since it's not displayed anyway?
-      return pokemon.destroy();
+      return this.remove(pokemon, true, true);
     }
 
     if (location.location === 'mainboard') {

--- a/src/objects/player.object.ts
+++ b/src/objects/player.object.ts
@@ -18,7 +18,7 @@ import { defaultStyle } from './text.helpers';
 
 const MAX_MAINBOARD_POKEMON = 6;
 
-export class Player extends Phaser.GameObjects.Group {
+export class Player extends Phaser.GameObjects.GameObject {
   hp = 100;
   gold = 20;
   /** Consecutive win/loss streak */
@@ -51,8 +51,7 @@ export class Player extends Phaser.GameObjects.Group {
     private readonly pool: ShopPool,
     private visible = false
   ) {
-    super(scene);
-    super.setVisible(visible);
+    super(scene, 'player');
 
     // not part of group - always visible
     // TODO: move to game scene?
@@ -329,7 +328,7 @@ export class Player extends Phaser.GameObjects.Group {
       getSideboardLocationForCoordinates(pokemon);
     if (!location) {
       // just destroy since it's not displayed anyway?
-      return this.remove(pokemon, true, true);
+      return pokemon.destroy();
     }
 
     if (location.location === 'mainboard') {

--- a/src/objects/player.object.ts
+++ b/src/objects/player.object.ts
@@ -19,6 +19,10 @@ import { defaultStyle } from './text.helpers';
 const MAX_MAINBOARD_POKEMON = 6;
 
 export class Player extends Phaser.GameObjects.GameObject {
+  static Events = {
+    SELECT: 'selectPlayer',
+  };
+
   hp = 100;
   gold = 20;
   /** Consecutive win/loss streak */
@@ -43,24 +47,27 @@ export class Player extends Phaser.GameObjects.GameObject {
 
   currentShop: PokemonName[];
 
+  private visible: boolean;
+
   constructor(
     scene: GameScene,
     public playerName: string,
     x: number,
     y: number,
     private readonly pool: ShopPool,
-    private visible = false
+    private isHumanPlayer = false
   ) {
     super(scene, 'player');
+    this.visible = isHumanPlayer;
 
     // not part of group - always visible
     // TODO: move to game scene?
-    this.nameInList = scene.add.text(
-      x,
-      y,
-      `${this.playerName} - ${this.hp}`,
-      defaultStyle
-    );
+    this.nameInList = scene.add
+      .text(x, y, `${this.playerName} - ${this.hp}`, defaultStyle)
+      .setInteractive()
+      .on(Phaser.Input.Events.POINTER_DOWN, () => {
+        this.emit(Player.Events.SELECT);
+      });
   }
 
   update() {
@@ -69,6 +76,15 @@ export class Player extends Phaser.GameObjects.GameObject {
 
   updatePosition(x: number, y: number) {
     this.nameInList.setPosition(x, y);
+  }
+
+  setVisible(visible: boolean): this {
+    this.visible = visible;
+    [...flatten(this.mainboard), ...this.sideboard].forEach(pokemon =>
+      pokemon?.setVisible(visible)
+    );
+    this.updateSynergies();
+    return this;
   }
 
   /**
@@ -183,7 +199,7 @@ export class Player extends Phaser.GameObjects.GameObject {
       scene: this.scene,
       ...getCoordinatesForSideboardIndex(empty),
       name: pokemon,
-      side: 'player',
+      side: this.isHumanPlayer ? 'player' : 'enemy',
     }).setVisible(this.visible);
     this.scene.add.existing(newPokemon);
     this.sideboard[empty] = newPokemon;
@@ -274,7 +290,7 @@ export class Player extends Phaser.GameObjects.GameObject {
         x: 0,
         y: 0,
         name: evolutionName,
-        side: 'player',
+        side: this.isHumanPlayer ? 'player' : 'enemy',
       }).setVisible(this.visible);
       this.scene.add.existing(evo);
       this.setPokemonAtLocation(evoLocation, evo);
@@ -379,15 +395,16 @@ export class Player extends Phaser.GameObjects.GameObject {
         return b.category > a.category ? -1 : 1;
       });
 
+    // hide all synergy markers
+    Object.values(this.synergyMarkers).forEach(marker => {
+      marker.setVisible(false).setActive(false);
+    });
+
     if (!this.visible) {
       // if this is hidden, don't bother rendering synergies.
       return;
     }
 
-    // hide all synergy markers
-    Object.values(this.synergyMarkers).forEach(marker => {
-      marker.setVisible(false).setActive(false);
-    });
     // then show and reposition the active ones
     this.synergies.slice(0, 9).forEach((synergy, index) => {
       if (!this.synergyMarkers[synergy.category]) {

--- a/src/scenes/game/combat/combat.scene.ts
+++ b/src/scenes/game/combat/combat.scene.ts
@@ -156,6 +156,9 @@ export class CombatScene extends Scene {
       });
     });
 
+    // check immediately in case someone is open-forting
+    this.checkRoundEnd();
+
     flatten(this.board)
       .filter(isDefined)
       .forEach(pokemon => this.setTurn(pokemon));

--- a/src/scenes/game/game.scene.ts
+++ b/src/scenes/game/game.scene.ts
@@ -144,7 +144,8 @@ export class GameScene extends Phaser.Scene {
   /* TEMPORARY JUNK */
   nextRoundButton: Button;
   shopButton: Phaser.GameObjects.GameObject;
-  player: Player;
+  humanPlayer: Player;
+  currentVisiblePlayer: Player;
   playerGoldText: Phaser.GameObjects.Text;
   playerHPText: Phaser.GameObjects.Text;
   sellArea: Phaser.GameObjects.Shape;
@@ -230,22 +231,34 @@ export class GameScene extends Phaser.Scene {
         new Player(this, name, 620, 100 + 30 * index, this.pool, index === 0)
       )
     );
+    this.players.forEach(player => {
+      player.on(Player.Events.SELECT, () => {
+        this.currentVisiblePlayer.setVisible(false);
+        player.setVisible(true);
+        this.currentVisiblePlayer = player;
+      });
+    });
     // players[0] is always the human player
-    [this.player] = this.players;
+    [this.humanPlayer] = this.players;
+    this.currentVisiblePlayer = this.humanPlayer;
+
     this.playerGoldText = this.add.text(
       50,
       100,
-      `Gold: ${this.player.gold}`,
+      `Gold: ${this.currentVisiblePlayer.gold}`,
       defaultStyle
     );
     this.playerHPText = this.add.text(
       50,
       120,
-      `HP: ${this.player.hp}`,
+      `HP: ${this.currentVisiblePlayer.hp}`,
       defaultStyle
     );
 
-    this.scene.launch(ShopScene.KEY, { player: this.player, pool: this.pool });
+    this.scene.launch(ShopScene.KEY, {
+      player: this.humanPlayer,
+      pool: this.pool,
+    });
     this.shop = this.scene.get(ShopScene.KEY) as ShopScene;
     this.shop.setCentre({ x: SHOP_X, y: SHOP_Y });
 
@@ -284,7 +297,7 @@ export class GameScene extends Phaser.Scene {
       .setInteractive()
       .on(Phaser.Input.Events.POINTER_DOWN, (event: Phaser.Input.Pointer) => {
         if (event.leftButtonDown()) {
-          this.player.sellPokemon(this.selectedPokemon as PokemonObject);
+          this.humanPlayer.sellPokemon(this.selectedPokemon as PokemonObject);
         }
       });
 
@@ -300,8 +313,8 @@ export class GameScene extends Phaser.Scene {
     this.currentRoundText.setText(
       `Round ${this.currentStage + 1}-${this.currentRound}`
     );
-    this.playerGoldText.setText(`Gold: ${this.player.gold}`);
-    this.playerHPText.setText(`HP: ${this.player.hp}`);
+    this.playerGoldText.setText(`Gold: ${this.currentVisiblePlayer.gold}`);
+    this.playerHPText.setText(`HP: ${this.currentVisiblePlayer.hp}`);
 
     // Display players in order without reordering array.
     [...this.players]
@@ -323,7 +336,7 @@ export class GameScene extends Phaser.Scene {
   startCombat() {
     // take AI player turns
     this.players.forEach(player => {
-      if (player !== this.player) {
+      if (player !== this.humanPlayer) {
         player.takeEnemyTurn();
       }
     });
@@ -332,7 +345,7 @@ export class GameScene extends Phaser.Scene {
     // this deselects Pokemon, closes any info cards and so on.
     this.events.emit(Phaser.Input.Events.POINTER_DOWN, { x: 0, y: 0 });
     // hide all the prep-only stuff
-    this.player.mainboard.forEach(col =>
+    this.currentVisiblePlayer.mainboard.forEach(col =>
       col.forEach(pokemon => pokemon?.setVisible(false))
     );
     this.prepGrid.setVisible(false);
@@ -349,11 +362,11 @@ export class GameScene extends Phaser.Scene {
     pairings.forEach(pairing => {
       let [player1, player2] = [pairing[0], pairing[1]];
       // force human player to be player 1
-      if (player2 === this.player) {
+      if (player2 === this.humanPlayer) {
         [player1, player2] = [player2, player1];
       }
 
-      if (player1 === this.player) {
+      if (player1 === this.humanPlayer) {
         // human player: show combat
         this.scene.launch(CombatScene.KEY, {
           player: player1,
@@ -402,7 +415,7 @@ export class GameScene extends Phaser.Scene {
 
   startDowntime() {
     // TODO: handle other players losing
-    if (this.player.hp <= 0) {
+    if (this.humanPlayer.hp <= 0) {
       this.add
         .text(GRID_X, GRID_Y, `YOU LOSE`, {
           ...defaultStyle,
@@ -422,7 +435,7 @@ export class GameScene extends Phaser.Scene {
 
     // other players that are still alive
     const remainingPlayers = this.players.filter(
-      player => player !== this.player && player.hp > 0
+      player => player !== this.humanPlayer && player.hp > 0
     );
     if (remainingPlayers.length <= 0) {
       this.add
@@ -452,7 +465,7 @@ export class GameScene extends Phaser.Scene {
     this.players.forEach(player => player.gainRoundEndGold());
 
     // show all the prep-only stuff
-    this.player.mainboard.forEach(col =>
+    this.currentVisiblePlayer.mainboard.forEach(col =>
       col.forEach(pokemon => pokemon?.setVisible(true))
     );
     this.prepGrid.setVisible(true);
@@ -469,7 +482,7 @@ export class GameScene extends Phaser.Scene {
       getMainboardLocationForCoordinates(clickCoords) ||
       getSideboardLocationForCoordinates(clickCoords);
 
-    const pokemon = this.player.getPokemonAtLocation(select);
+    const pokemon = this.humanPlayer.getPokemonAtLocation(select);
     if (!pokemon) {
       return;
     }
@@ -498,7 +511,7 @@ export class GameScene extends Phaser.Scene {
       return;
     }
 
-    this.player.movePokemon(selectedPokemon, newLocation);
+    this.humanPlayer.movePokemon(selectedPokemon, newLocation);
   }
 
   /**

--- a/src/scenes/game/game.scene.ts
+++ b/src/scenes/game/game.scene.ts
@@ -233,9 +233,7 @@ export class GameScene extends Phaser.Scene {
     );
     this.players.forEach(player => {
       player.on(Player.Events.SELECT, () => {
-        this.currentVisiblePlayer.setVisible(false);
-        player.setVisible(true);
-        this.currentVisiblePlayer = player;
+        this.watchPlayer(player);
       });
     });
     // players[0] is always the human player
@@ -334,6 +332,8 @@ export class GameScene extends Phaser.Scene {
   }
 
   startCombat() {
+    // switch view back to own board
+    this.watchPlayer(this.humanPlayer);
     // take AI player turns
     this.players.forEach(player => {
       if (player !== this.humanPlayer) {
@@ -472,6 +472,12 @@ export class GameScene extends Phaser.Scene {
     this.input.enabled = true;
 
     this.nextRoundButton.setActive(true).setVisible(true);
+  }
+
+  watchPlayer(player: Player) {
+    this.currentVisiblePlayer.setVisible(false);
+    player.setVisible(true);
+    this.currentVisiblePlayer = player;
   }
 
   /**


### PR DESCRIPTION
This commit separates out the logic for `this.player` within the `GameScene`,
splitting it into the `humanPlayer` and the `currentlyVisiblePlayer`.
This lets you switch between different players to look at their board positioning,
sideboard units and amount of gold remaining.