### PR TITLE
Try to fix Dragon Rush

### DIFF
--- a/src/core/moves/dragon-rush.ts
+++ b/src/core/moves/dragon-rush.ts
@@ -4,8 +4,8 @@ import {
   Coords,
   getAngle,
   getFacing,
-  getFurthestTarget,
   getOppositeSide,
+  inBounds,
   optimiseAOE,
 } from '../../scenes/game/combat/combat.helpers';
 import { CombatBoard } from '../../scenes/game/combat/combat.scene';
@@ -31,34 +31,31 @@ const move = {
   },
   range: 99,
   getTarget(board: CombatBoard, user: Coords) {
-    const furthestPokemonCoords = getFurthestTarget({
-      board,
-      user,
-    });
-    if (!furthestPokemonCoords) {
-      return undefined;
-    }
-    const { x, y } = furthestPokemonCoords;
+    console.log(
+      'Optimising',
+      optimiseAOE({
+        board,
+        user,
+        range: 99,
+        getAOE: this.getAOE,
+        targetting: 'ground',
+        needsEmpty: true,
+      })
+    );
     return optimiseAOE({
       board,
       user,
       range: 99,
       getAOE: this.getAOE,
       targetting: 'ground',
-      pool: [
-        { x: x - 1, y },
-        { x: x + 1, y },
-        { x, y: y - 1 },
-        { x, y: y + 1 },
-      ],
+      needsEmpty: true,
     });
   },
   /**
-   * A line from user to target.
+   * A wide line from user to target
    */
   getAOE(targetCoords: Coords, myCoords: Coords) {
-    // TODO: support width and make this 2-width
-    return interpolateLineAOE(myCoords, targetCoords);
+    return interpolateLineAOE(myCoords, targetCoords, { width: 3 });
   },
   use({
     scene,
@@ -92,23 +89,28 @@ const move = {
     // wait through the first bit of the dragon rush animation
     scene.time.addEvent({
       callback: () => {
-        // if target coord is somehow occupied now, don't move
-        // TODO: retarget
-        if (board[targetCoords.x][targetCoords.y] !== undefined) {
-          onComplete();
-          return;
-        }
-        scene.movePokemon(userCoords, targetCoords, onComplete);
-        this.getAOE(targetCoords, userCoords).forEach(({ x, y }) => {
-          const thisTarget = board[x][y];
-          if (thisTarget?.side === getOppositeSide(user.side)) {
-            const damage = calculateDamage(user, thisTarget, {
-              damage: this.damage[user.basePokemon.stage - 1],
-              defenseStat: this.defenseStat,
-            });
-            scene.causeDamage(user, thisTarget, damage, { isAOE: true });
+        let realTarget: Coords | undefined = targetCoords;
+        // if target is occupied, find another target
+        if (board[realTarget.x][realTarget.y] !== undefined) {
+          realTarget = this.getTarget(board, user);
+          if (!realTarget) {
+            onComplete();
+            return;
           }
-        });
+        }
+        scene.movePokemon(userCoords, realTarget, onComplete);
+        this.getAOE(realTarget, userCoords)
+          .filter(coords => inBounds(board, coords))
+          .forEach(({ x, y }) => {
+            const thisTarget = board[x][y];
+            if (thisTarget?.side === getOppositeSide(user.side)) {
+              const damage = calculateDamage(user, thisTarget, {
+                damage: this.damage[user.basePokemon.stage - 1],
+                defenseStat: this.defenseStat,
+              });
+              scene.causeDamage(user, thisTarget, damage, { isAOE: true });
+            }
+          });
         // reset target after movement
         user.currentTarget = undefined;
       },

--- a/src/core/moves/dragon-rush.ts
+++ b/src/core/moves/dragon-rush.ts
@@ -31,17 +31,6 @@ const move = {
   },
   range: 99,
   getTarget(board: CombatBoard, user: Coords) {
-    console.log(
-      'Optimising',
-      optimiseAOE({
-        board,
-        user,
-        range: 99,
-        getAOE: this.getAOE,
-        targetting: 'ground',
-        needsEmpty: true,
-      })
-    );
     return optimiseAOE({
       board,
       user,

--- a/src/math.helpers.spec.ts
+++ b/src/math.helpers.spec.ts
@@ -132,5 +132,71 @@ describe('math helpers', () => {
         { x: 3, y: 4 },
       ]);
     });
+
+    it(`should interpolate a wide straight line
+        .....
+        .****
+        .A**B
+        .****`, () => {
+      expect(
+        interpolateLineAOE({ x: 1, y: 1 }, { x: 4, y: 1 }, { width: 3 })
+      ).toEqual([
+        { x: 1, y: 1 },
+        { x: 1, y: 2 },
+        { x: 1, y: 0 },
+        { x: 2, y: 1 },
+        { x: 2, y: 2 },
+        { x: 2, y: 0 },
+        { x: 3, y: 1 },
+        { x: 3, y: 2 },
+        { x: 3, y: 0 },
+        { x: 4, y: 1 },
+        { x: 4, y: 2 },
+        { x: 4, y: 0 },
+      ]);
+    });
+
+    it(`should interpolate a wide horizontal-angled line
+        ...**
+        .***B
+        .A***
+        .**.`, () => {
+      expect(
+        interpolateLineAOE({ x: 1, y: 1 }, { x: 4, y: 2 }, { width: 3 })
+      ).toEqual([
+        { x: 1, y: 1 },
+        { x: 1, y: 2 },
+        { x: 1, y: 0 },
+        { x: 2, y: 1 },
+        { x: 2, y: 2 },
+        { x: 2, y: 0 },
+        { x: 3, y: 2 },
+        { x: 3, y: 3 },
+        { x: 3, y: 1 },
+        { x: 4, y: 2 },
+        { x: 4, y: 3 },
+        { x: 4, y: 1 },
+      ]);
+    });
+
+    it(`should interpolate a wide vertical-angled line
+        .*B*.
+        .***.
+        *A*..
+        .....`, () => {
+      expect(
+        interpolateLineAOE({ x: 1, y: 1 }, { x: 2, y: 3 }, { width: 3 })
+      ).toEqual([
+        { x: 1, y: 1 },
+        { x: 2, y: 1 },
+        { x: 0, y: 1 },
+        { x: 2, y: 2 },
+        { x: 3, y: 2 },
+        { x: 1, y: 2 },
+        { x: 2, y: 3 },
+        { x: 3, y: 3 },
+        { x: 1, y: 3 },
+      ]);
+    });
   });
 });

--- a/src/math.helpers.ts
+++ b/src/math.helpers.ts
@@ -6,15 +6,28 @@ import { Coords } from './scenes/game/combat/combat.helpers';
  */
 function interpolateHorizontal(
   { x: x1, y: y1 }: Coords,
-  { x: x2, y: y2 }: Coords
+  { x: x2, y: y2 }: Coords,
+  width: 1 | 3
 ): Coords[] {
   const line = [];
   for (let i = x1; i <= x2; i++) {
+    // linear interpolation between y1 and y2 based on the % of i between x1 and x2
+    const interpolatedY = y1 + ((y2 - y1) * (i - x1)) / (x2 - x1);
     line.push({
       x: i,
-      // linear interpolation between y1 and y2 based on the % of i between x1 and x2
-      y: Math.round(y1 + ((y2 - y1) * (i - x1)) / (x2 - x1)),
+      y: Math.round(interpolatedY),
     });
+    if (width === 3) {
+      // push above and below
+      line.push({
+        x: i,
+        y: Math.round(interpolatedY) + 1,
+      });
+      line.push({
+        x: i,
+        y: Math.round(interpolatedY) - 1,
+      });
+    }
   }
   return line;
 }
@@ -25,15 +38,28 @@ function interpolateHorizontal(
  */
 function interpolateVertical(
   { x: x1, y: y1 }: Coords,
-  { x: x2, y: y2 }: Coords
+  { x: x2, y: y2 }: Coords,
+  width: 1 | 3
 ): Coords[] {
   const line = [];
   for (let i = y1; i <= y2; i++) {
+    // linear interpolation between x1 and x2 based on the % of i between y1 and y2
+    const interpolatedX = x1 + ((x2 - x1) * (i - y1)) / (y2 - y1);
     line.push({
-      // linear interpolation between x1 and x2 based on the % of i between y1 and y2
-      x: Math.round(x1 + ((x2 - x1) * (i - y1)) / (y2 - y1)),
+      x: Math.round(interpolatedX),
       y: i,
     });
+    if (width === 3) {
+      // push above and below
+      line.push({
+        x: Math.round(interpolatedX) + 1,
+        y: i,
+      });
+      line.push({
+        x: Math.round(interpolatedX) - 1,
+        y: i,
+      });
+    }
   }
   return line;
 }
@@ -46,9 +72,8 @@ function interpolateVertical(
  */
 export function interpolateLineAOE(
   p1: Coords,
-  p2: Coords
-  // TODO: support width
-  //  { width = 1 }: { width: number }
+  p2: Coords,
+  { width = 1 }: { width?: 1 | 3 } = {}
 ): Coords[] {
   const dx = Math.abs(p2.x - p1.x);
   const dy = Math.abs(p2.y - p1.y);
@@ -59,12 +84,12 @@ export function interpolateLineAOE(
   if (dx >= dy) {
     // most horizontal line
     return p1.x < p2.x
-      ? interpolateHorizontal(p1, p2)
-      : interpolateHorizontal(p2, p1);
+      ? interpolateHorizontal(p1, p2, width)
+      : interpolateHorizontal(p2, p1, width);
   }
 
   // mostly vertical line
   return p1.y < p2.y
-    ? interpolateVertical(p1, p2)
-    : interpolateVertical(p2, p1);
+    ? interpolateVertical(p1, p2, width)
+    : interpolateVertical(p2, p1, width);
 }

--- a/src/scenes/game/shop.helpers.spec.ts
+++ b/src/scenes/game/shop.helpers.spec.ts
@@ -15,7 +15,7 @@ function customRng(results: number[]) {
   };
 }
 
-describe.only('shop rerolling', () => {
+describe('shop rerolling', () => {
   const origRandom = Math.random;
 
   afterEach(() => {


### PR DESCRIPTION
Dragon Rush is currently extremely unreliable; it often doesn't cast,
it sometimes casts on the spot (???) and otherwise has unreliable damage.

This commit attempts to improve the targetting/AOE by making it target anyone
rather than just the furthest enemy, in case there are better paths to blast.

It also adds support for wider line AOEs and makes the AOE 3 wide,
as a way to patch it up further until I figure out how to make it good.