### PR TITLE
Improve AI logic

### DIFF
--- a/src/core/pokemon.helpers.ts
+++ b/src/core/pokemon.helpers.ts
@@ -1,0 +1,19 @@
+import { Pokemon } from './pokemon.model';
+
+/**
+ * Returns the approximate strength of a Pokemon, for AI logic
+ *
+ * The math uses `stage * 2.5 + tier`, which looks approximately like this:
+ *
+ * ```
+ *       5   4    3    2   1
+ *  3 | 12.| 11.| 10.| 9.| 8.|
+ *  2 | 10 | 9  | 8  | 7 | 6 |
+ *  1 | 7. | 6. | 5. | 4.| 3.|
+ * ```
+ *
+ * This is pretty close to how most people rate units in a vacuum (for TFT at least)
+ */
+export function getPokemonStrength(p: Pokemon) {
+  return p.stage * 2.5 + p.tier;
+}

--- a/src/objects/ai/ai.ts
+++ b/src/objects/ai/ai.ts
@@ -1,5 +1,6 @@
-import { Category } from '../../core/game.model';
-import { Pokemon, pokemonData, PokemonName } from '../../core/pokemon.model';
+import { Category, getSynergyTier, synergyData } from '../../core/game.model';
+import { getPokemonStrength } from '../../core/pokemon.helpers';
+import { pokemonData, PokemonName } from '../../core/pokemon.model';
 import { flatten, isDefined } from '../../helpers';
 import { Player } from '../player.object';
 import { PokemonObject } from '../pokemon.object';
@@ -12,33 +13,110 @@ export interface AIStrategy {
   readonly prioritiseBoard: (player: Player) => PokemonObject[];
   /** Given a player (with access to their gold/board), decide whether to reroll the sholl or not */
   readonly decideReroll: (player: Player) => boolean;
+  /** Given a player (with access to their main/sideboard), decide whether to sell any Pokemon */
+  readonly decideSells?: (player: Player) => PokemonObject[];
 }
 
 /**
- * Returns the strength difference between two Pokemon, for sorting algos
- *
- * The math uses `stage * 2.5 + tier`, which looks approximately like this:
- *
- * ```
- *       5   4    3    2   1
- *  3 | 12.| 11.| 10.| 9.| 8.|
- *  2 | 10 | 9  | 8  | 7 | 6 |
- *  1 | 7. | 6. | 5. | 4.| 3.|
- * ```
- *
- * This is pretty much how most people rate units in a vacuum (for TFT at least)
+ * Board prioritisation logic
+ * Sorts Pokemon by a provided comparator, then filters for duplicates
  */
-function pokemonDiff(a: Pokemon, b: Pokemon): number {
-  return a.stage * 2.5 + a.tier - (b.stage * 2.5 + b.tier);
+function genericPrioritiseBoard(
+  player: Player,
+  sortFn = (a: PokemonObject, b: PokemonObject) =>
+    getPokemonStrength(b.basePokemon) - getPokemonStrength(a.basePokemon)
+): PokemonObject[] {
+  const sortedPokemon = [...flatten(player.mainboard), ...player.sideboard]
+    .filter(isDefined)
+    .sort(sortFn);
+
+  // get rid of duplicates (only relevant if we have sideboard units to swap to)
+  if (sortedPokemon.length > player.level) {
+    const seen: { [k in PokemonName]?: boolean } = {};
+    let swapsMade = 0;
+    for (let i = 0; i < player.level; i++) {
+      if (seen[sortedPokemon[i].basePokemon.base]) {
+        // if seen, swap it with someone past the end of the mainboard
+        [sortedPokemon[i], sortedPokemon[player.level + swapsMade]] = [
+          sortedPokemon[player.level + swapsMade],
+          sortedPokemon[i],
+        ];
+        swapsMade++;
+      }
+      seen[sortedPokemon[i].basePokemon.base] = true;
+    }
+  }
+
+  return sortedPokemon;
 }
 
-const genericPrioritiseBoard: (player: Player) => PokemonObject[] = (
-  player: Player
-) => {
-  return [...flatten(player.mainboard), ...player.sideboard]
+/**
+ * Sell logic.
+ * - Sells excess copies except for one Pokemon we're targetting to 3*
+ * - Sells excess copies for Pokemon we've already 3*d
+ * - Sells random Pokemon which won't contribute to board synergies
+ */
+function genericDecideSells(player: Player) {
+  // don't bother selling if we can afford more Pokemon
+  if (player.canAddPokemonToSideboard()) {
+    return [];
+  }
+
+  // count number of copies of each pokemon
+  const totalCopies: { [k in PokemonName]?: number } = {};
+  [...flatten(player.mainboard), ...player.sideboard]
     .filter(isDefined)
-    .sort((a, b) => pokemonDiff(a.basePokemon, b.basePokemon));
-};
+    .forEach(pokemon => {
+      const count = 3 ** (pokemon.basePokemon.stage - 1);
+      totalCopies[pokemon.basePokemon.base] =
+        (totalCopies[pokemon.basePokemon.base] ?? 0) + count;
+    });
+
+  // find Pokemon with most copies: that's the current reroll target
+  const allCopies = Object.keys(totalCopies) as PokemonName[];
+  let rerollTarget: PokemonName = allCopies[0];
+  allCopies.forEach(pokemonName => {
+    if (
+      (totalCopies[pokemonName] ?? 0) > (totalCopies[rerollTarget] ?? 0) &&
+      // if we already capped them, they're not a reroll target anymore
+      (totalCopies[pokemonName] ?? 0) < 9
+    ) {
+      rerollTarget = pokemonName;
+    }
+  });
+
+  return player.sideboard.filter(isDefined).filter(pokemon => {
+    // if already have a 3* version, sell
+    if ((totalCopies[pokemon.basePokemon.base] ?? 0) >= 9) {
+      return true;
+    }
+
+    // if not rerolling for that Pokemon and have excess copies, sell
+    if (
+      (totalCopies[pokemon.basePokemon.base] ?? 0) > 3 &&
+      pokemon.basePokemon.base !== rerollTarget
+    ) {
+      return true;
+    }
+
+    // if doesn't contribute to ANY on-board synergies, sell
+    if (
+      !pokemon.basePokemon.categories.some(
+        category => player.synergyMap[category]
+      )
+    ) {
+      return true;
+    }
+
+    // at higher levels, sell random weaker units
+    // level 3 start selling 1* 1-costs, ramping up to selling excess 2/3 costs
+    if (getPokemonStrength(pokemon.basePokemon) <= player.level + 1) {
+      return true;
+    }
+
+    return false;
+  });
+}
 
 /** Simple flexible AI which donkey rolls, prioritising units with categories that match its current Pokemon */
 const basicFlexAI: AIStrategy = {
@@ -55,73 +133,132 @@ const basicFlexAI: AIStrategy = {
       );
     return player.currentShop.filter(
       pokemon =>
-        Object.keys(hasType).length < 3 ||
+        Object.keys(hasType).length < 5 ||
         pokemonData[pokemon].categories.some(category => hasType[category])
     );
   },
   prioritiseBoard: genericPrioritiseBoard,
   // always reroll if enough gold to buy some units
-  decideReroll: (player: Player) => player.gold > 6,
+  decideReroll: (player: Player) =>
+    player.gold > 6 && player.canAddPokemonToSideboard(),
+  decideSells: genericDecideSells,
 };
 
-const hardForceAI = (forced: readonly Category[]) => ({
-  name: `Hard Force ${forced.join(' + ')}`,
-  decideBuys: (player: Player) => {
-    return player.currentShop.filter(pokemon =>
-      pokemonData[pokemon].categories.some(category =>
-        forced.includes(category)
-      )
-    );
-  },
-  prioritiseBoard: (player: Player) => {
-    return [...flatten(player.mainboard), ...player.sideboard]
-      .filter(isDefined)
-      .sort((a, b) => {
+function generateHardForceAI(forced: readonly Category[]): AIStrategy {
+  return {
+    name: `Hard Force ${forced.join(' + ')}`,
+    /** Buy Pokemon of the categories being forced */
+    decideBuys: (player: Player) => {
+      const slightlyFlex = forced.length === 1;
+      return player.currentShop.filter(pokemon =>
+        pokemonData[pokemon].categories.some(category => {
+          // if board has holes and no sideboard units to fill, just buy whatever you can
+          if (
+            player.canAddPokemonToMainboard() &&
+            player.sideboard.every(slot => !isDefined(slot))
+          ) {
+            return true;
+          }
+
+          // if part of the forced build, always buy
+          if (forced.includes(category)) {
+            return true;
+          }
+
+          // flexible logic (for when only one category is forced)
+          // can fill out the board with extra synergies that fit
+          if (slightlyFlex) {
+            // if this Pokemon would give an extra tier of a synergy, buy and hold
+            const synergyCount = player.synergyMap[category];
+            if (
+              synergyCount &&
+              getSynergyTier(
+                synergyData[category].thresholds,
+                synergyCount + 1
+              ) > getSynergyTier(synergyData[category].thresholds, synergyCount)
+            ) {
+              return true;
+            }
+          }
+          return false;
+        })
+      );
+    },
+    /**
+     * Prioritise Pokemon that will match the forced types
+     * and pick the ones that are stronger
+     */
+    prioritiseBoard: (player: Player) => {
+      return genericPrioritiseBoard(player, (a, b) => {
         // number of categories matching the force
         const categoryCountDiff =
           b.basePokemon.categories.filter(category => forced.includes(category))
             .length -
           a.basePokemon.categories.filter(category => forced.includes(category))
             .length;
+        const pokemonStrengthDiff =
+          getPokemonStrength(b.basePokemon) - getPokemonStrength(a.basePokemon);
         // pick Pokemon that fit the categories, then order by power
-        return categoryCountDiff || pokemonDiff(b.basePokemon, a.basePokemon);
+        return categoryCountDiff || pokemonStrengthDiff;
       });
-  },
-  decideReroll: (player: Player) => player.gold > 6,
-});
+    },
+    /** Donkey as long as there's money and room to buy units */
+    decideReroll: (player: Player) =>
+      player.gold > 6 && player.canAddPokemonToSideboard(),
+    decideSells: genericDecideSells,
+  };
+}
 
-const allAI: AIStrategy[] = [
+const hardForceStrategies: AIStrategy[] = [
   // single vertical trait comps
-  hardForceAI(['dark']),
-  // TODO: when there are 6 fire, sweeper etc add them here
+  // comps capable of filling 6 vertical
+  generateHardForceAI(['dark']),
+  generateHardForceAI(['fire']),
+  generateHardForceAI(['bulky attacker']),
+  generateHardForceAI(['sweeper']),
+
+  // comps that need a bit of flex
+  generateHardForceAI(['bug']),
+  generateHardForceAI(['poison']),
+  generateHardForceAI(['sweeper']),
+  generateHardForceAI(['ground']),
 
   // verticals + supports
-  hardForceAI(['poison', 'grass']),
-  hardForceAI(['poison', 'electric']),
-  hardForceAI(['sweeper', 'electric', 'steel']),
-  hardForceAI(['fire', 'support']),
-  hardForceAI(['revenge killer', 'electric']),
+  generateHardForceAI(['poison', 'grass']),
+  generateHardForceAI(['poison', 'electric']),
+  generateHardForceAI(['poison', 'disruptor']),
+  generateHardForceAI(['sweeper', 'steel']),
+  generateHardForceAI(['fire', 'support']),
+  generateHardForceAI(['revenge killer', 'electric']),
+  generateHardForceAI(['ground', 'rock']),
 
-  // frontline + backline + support
-  hardForceAI(['psychic', 'wall', 'ice']),
-  hardForceAI(['psychic', 'bulky attacker', 'ice']),
-  hardForceAI(['sweeper', 'wall', 'grass']),
-  hardForceAI(['sweeper', 'bulky attacker', 'grass']),
-  hardForceAI(['wallbreaker', 'wall', 'support']),
+  // generic frontline + backline
+  generateHardForceAI(['psychic', 'wall']),
+  generateHardForceAI(['psychic', 'bulky attacker']),
+  generateHardForceAI(['sweeper', 'wall']),
+  generateHardForceAI(['sweeper', 'bulky attacker']),
+  generateHardForceAI(['wallbreaker', 'wall']),
 
   // me mech
-  hardForceAI(['pivot', 'steel', 'water']),
+  generateHardForceAI(['pivot']),
+  generateHardForceAI(['pivot', 'dark']),
 
   // force some specific carries
-  hardForceAI(pokemonData.weedle.categories),
-  hardForceAI(pokemonData.magikarp.categories),
-  hardForceAI(pokemonData.larvitar.categories),
-  hardForceAI(pokemonData.exeggcute.categories),
-  hardForceAI(pokemonData.scyther.categories),
-
-  basicFlexAI,
+  generateHardForceAI(pokemonData.weedle.categories),
+  generateHardForceAI(pokemonData.magikarp.categories),
+  generateHardForceAI(pokemonData.larvitar.categories),
+  generateHardForceAI(pokemonData.exeggcute.categories),
+  generateHardForceAI(pokemonData.scyther.categories),
 ];
 
 export function getRandomAI(): AIStrategy {
-  return allAI[Math.floor(Math.random() * allAI.length)];
+  // add a few flex players every game
+  if (Math.random() < 0.33) {
+    return basicFlexAI;
+  }
+
+  // plus some hard forcers
+  return hardForceStrategies[
+    Math.floor(Math.random() * hardForceStrategies.length)
+  ];
 }

--- a/src/objects/player.object.ts
+++ b/src/objects/player.object.ts
@@ -56,6 +56,9 @@ export class Player extends Phaser.GameObjects.GameObject {
   synergies: { category: Category; count: number }[] = [];
   synergyMarkers: { [k in Category]?: SynergyMarker } = {};
 
+  /** Used mostly for AI to quickly determine if a synergy exists or not */
+  synergyMap: { [k in Category]?: number } = {};
+
   readonly pool: ShopPool;
   currentShop: PokemonName[];
 
@@ -199,6 +202,7 @@ export class Player extends Phaser.GameObjects.GameObject {
   }
 
   sellPokemon(pokemon: PokemonObject) {
+    console.log('player', this.playerName, 'sold', pokemon.basePokemon.name);
     if (pokemon.basePokemon.stage === 1) {
       this.gold += pokemon.basePokemon.tier;
     } else if (pokemon.basePokemon.stage === 2) {
@@ -405,6 +409,7 @@ export class Player extends Phaser.GameObjects.GameObject {
           synergyMap[category] = newValue;
         });
       });
+    this.synergyMap = synergyMap;
     // convert to an array of existing synergies
     this.synergies = Object.entries(synergyMap)
       .map(([category, count]) =>
@@ -467,6 +472,8 @@ export class Player extends Phaser.GameObjects.GameObject {
   }
 
   takeEnemyTurn() {
+    console.log(`${this.playerName}'s turn: ${this.aiStrategy.name}`);
+
     this.currentShop = this.pool.reroll(this, this.currentShop);
 
     this.aiStrategy.decideBuys(this).forEach(pokemon => {
@@ -535,5 +542,10 @@ export class Player extends Phaser.GameObjects.GameObject {
         selectedPokemon
       );
     });
+
+    // sell any pokemon (if relevant)
+    this.aiStrategy
+      .decideSells?.(this)
+      .forEach(toSell => this.sellPokemon(toSell));
   }
 }

--- a/src/scenes/game/game.helpers.ts
+++ b/src/scenes/game/game.helpers.ts
@@ -1,4 +1,7 @@
+import { getSynergyTier, synergyData } from '../../core/game.model';
+import { getPokemonStrength } from '../../core/pokemon.helpers';
 import { PokemonName } from '../../core/pokemon.model';
+import { flatten, isDefined } from '../../helpers';
 import { Player } from '../../objects/player.object';
 import { Coords } from './combat/combat.helpers';
 
@@ -184,4 +187,18 @@ export function getRandomNames(amount: number): string[] {
   ];
 
   return shuffle(names, amount).slice(0, amount);
+}
+
+export function calculateBoardStrength(player: Player): number {
+  const totalStrength = flatten(player.mainboard)
+    .filter(isDefined)
+    .map(pokemon => getPokemonStrength(pokemon.basePokemon))
+    .reduce((a, b) => a + b, 0);
+  const totalSynergyTiers = player.synergies
+    .map(synergy =>
+      getSynergyTier(synergyData[synergy.category].thresholds, synergy.count)
+    )
+    .reduce((a, b) => a + 2 ** (b - 1), 0);
+
+  return totalStrength + totalSynergyTiers;
 }

--- a/src/scenes/game/game.scene.ts
+++ b/src/scenes/game/game.scene.ts
@@ -14,6 +14,7 @@ import {
 } from './combat/combat.scene';
 import {
   BOARD_WIDTH,
+  calculateBoardStrength,
   CELL_WIDTH,
   GameMode,
   getRandomNames,
@@ -421,11 +422,12 @@ export class GameScene extends Phaser.Scene {
             this.startDowntime();
           });
       } else {
-        // AI players: after combat ends, randomly determine a winner
+        // AI players: after combat ends, determine a winner based on how good their board
         this.scene
           .get(CombatScene.KEY)
           .events.once(CombatScene.Events.COMBAT_END, () => {
-            const won = Math.random() < 0.5;
+            const won =
+              calculateBoardStrength(player1) > calculateBoardStrength(player2);
             this.handleCombatResult(player1, won);
             this.handleCombatResult(player2, !won);
           });


### PR DESCRIPTION
This commit improves the AI a bit by adding the ability to:
 - Dedupe units on board to fit more synergies in
 - Sell units to clear their bench of useless units
 - Buy units a bit more flexibility for the `hardForceAI`