### PR TITLE
Consolidate buffs/debuffs into a proper stat stacking system

### DIFF
--- a/src/core/game.model.ts
+++ b/src/core/game.model.ts
@@ -374,11 +374,6 @@ it raises the Speed of other nearby allies.
             Math.round(getGridDistance(pokemon, user) / 70) <= range
         )
         .forEach(pokemon => {
-          console.log(
-            'buffing X',
-            pokemon.name,
-            getGridDistance(pokemon, user)
-          );
           const cog = scene.add
             .sprite(pokemon.x, pokemon.y, 'cog')
             .play('cog')

--- a/src/core/game.model.ts
+++ b/src/core/game.model.ts
@@ -347,12 +347,11 @@ at the end of each of their turns.
     category: 'electric',
     displayName: 'Electric: Motor Drive',
     description: `Whenever an Electric-type pokemon uses its move,
-it raises the Speed of the whole party.
+it raises the Speed of other nearby allies.
 
- (2) - 10% boost
- (4) - 20% boost
- (6) - 35% boost`,
-    thresholds: [2, 4, 6],
+ (2) - within 1 tile
+ (4) - within 2 tiles`,
+    thresholds: [2, 4],
     onMoveUse({ scene, board, user, count }) {
       const tier = getSynergyTier(this.thresholds, count);
       if (tier === 0) {
@@ -363,12 +362,23 @@ it raises the Speed of the whole party.
         return;
       }
 
-      const boost = tier === 1 ? 1.05 : tier === 2 ? 1.15 : 1.25;
+      const range = tier === 1 ? 1 : 2;
 
       flatten(board)
         .filter(pokemon => pokemon?.side === user.side)
         .filter(isDefined)
+        // FIXME: a visual distance is a bit hacky
+        .filter(
+          pokemon =>
+            pokemon !== user &&
+            Math.round(getGridDistance(pokemon, user) / 70) <= range
+        )
         .forEach(pokemon => {
+          console.log(
+            'buffing X',
+            pokemon.name,
+            getGridDistance(pokemon, user)
+          );
           const cog = scene.add
             .sprite(pokemon.x, pokemon.y, 'cog')
             .play('cog')
@@ -376,7 +386,7 @@ it raises the Speed of the whole party.
               cog.destroy();
             });
           pokemon.changeStats({
-            speed: boost,
+            speed: +1,
           });
         });
     },
@@ -497,23 +507,27 @@ the further they are from their target.
   ice: {
     category: 'ice',
     displayName: 'Ice: Glaciate',
-    description: `All enemy Pokemon are slowed.
+    description: `At the start of the round, all enemy Pokemon
+have their Speed lowered for a duration.
 
- (2) - 5% slower
- (3) - 10% slower`,
+ (2) - 4 seconds
+ (3) - 6 seconds`,
     thresholds: [2, 3],
     onRoundStart({ board, side, count }) {
       const tier = getSynergyTier(this.thresholds, count);
       if (tier === 0) {
         return;
       }
-      const slow = tier === 1 ? 0.95 : 0.9;
+      const duration = tier === 1 ? 4000 : 6000;
 
       flatten(board).forEach(pokemon => {
         if (pokemon && pokemon.side !== side) {
-          pokemon.changeStats({
-            speed: slow,
-          });
+          pokemon.changeStats(
+            {
+              speed: -1,
+            },
+            duration
+          );
         }
       });
     },
@@ -714,14 +728,12 @@ damage they can take from one hit.
   sweeper: {
     category: 'sweeper',
     displayName: 'Sweeper: Speed Boost',
-    description: `Sweepers gain a stack of increasing
-Speed every time they hit with an attack.
+    description: `Sweepers raise their Speed every other
+time they hit an opponent.
 
-Max 4 stacks.
-
- (2) - 5% Speed per stack
- (4) - 10% Speed per stack
- (6) - 20% Speed per stack`,
+ (2) - up to 2 times
+ (4) - up to 3 times
+ (6) - up to 4 times`,
     thresholds: [2, 4, 6],
     onHit({ attacker, count }) {
       const tier = getSynergyTier(this.thresholds, count);
@@ -729,28 +741,28 @@ Max 4 stacks.
         return;
       }
 
-      const perStack = tier === 1 ? 0.05 : tier === 2 ? 0.1 : 0.2;
+      const maxStacks = tier === 1 ? 2 : tier === 2 ? 3 : 4;
 
       if (
         attacker.basePokemon.categories.includes('sweeper') &&
-        // up to 4 stacks
-        attacker.synergyState.sweeper < 4
+        attacker.synergyState.sweeper < maxStacks * 2
       ) {
-        // bonus is additive, so calculate relative to previous increase
-        const currentBonus = 1 + perStack * attacker.synergyState.sweeper;
-        const newBonus = 1 + perStack * (attacker.synergyState.sweeper + 1);
-        attacker.changeStats({ speed: newBonus / currentBonus });
+        // count each hit,
         attacker.synergyState.sweeper++;
+        // buff every second hit
+        if (attacker.synergyState.sweeper % 2 === 0) {
+          attacker.changeStats({ speed: +1 });
+        }
       }
     },
   },
   'revenge killer': {
     category: 'revenge killer',
     displayName: 'Revenge Killer: Retaliate',
-    description: `Whenever an ally Pokemon faints,
-all Revenge Kilers get an Attack boost.
+    description: `Whenever an ally Pokemon faints, all Revenge Kilers
+boost their Attack, Special Attack and Speed.
 
- (2) - 50% Attack once
+ (2) - Stacks once
  (4) - Stacks up to three times`,
     thresholds: [2, 4],
     onDeath({ scene, board, pokemon, side, count }) {
@@ -792,7 +804,7 @@ all Revenge Kilers get an Attack boost.
               duration: 250,
               yoyo: true,
             });
-            boardPokemon.changeStats({ attack: 1.5 });
+            boardPokemon.changeStats({ attack: +1, specAttack: +1, speed: +1 });
             boardPokemon.synergyState.revengeKiller++;
           }
         });

--- a/src/core/moves/brave-bird.ts
+++ b/src/core/moves/brave-bird.ts
@@ -12,13 +12,13 @@ const move = {
   flags: {},
   damage: [30, 55, 90],
   get description() {
-    return `While above 50% health, {{user}} gets a 50% Speed boost. While below 50% health, it becomes brave, getting a 50% Attack boost and recovers ${this.damage.join(
+    return `{{user}} raises its speed while above 50% health. While below 50% health, raises its Attack instead, and recovers ${this.damage.join(
       '/'
     )} HP on hit.`;
   },
   onRoundStart({ self }: { self: PokemonObject }) {
     self.moveState = 'fast';
-    self.changeStats({ speed: 1.5 });
+    self.changeStats({ speed: +1 });
   },
   onBeingHit({ defender }: { defender: PokemonObject }) {
     // bit cheesy: toggle the buff state based on hp after being hit
@@ -28,7 +28,7 @@ const move = {
       defender.currentHP / defender.maxHP < 0.5
     ) {
       defender.moveState = 'slow';
-      defender.changeStats({ attack: 1.5, speed: 1 / 1.5 });
+      defender.changeStats({ attack: +1, speed: -1 });
     }
 
     if (
@@ -36,7 +36,7 @@ const move = {
       defender.currentHP / defender.maxHP > 0.5
     ) {
       defender.moveState = 'fast';
-      defender.changeStats({ attack: 1 / 1.5, speed: 1.5 });
+      defender.changeStats({ attack: -1, speed: +1 });
     }
   },
   onHit({ attacker }: { attacker: PokemonObject }) {

--- a/src/core/moves/dragon-dance.ts
+++ b/src/core/moves/dragon-dance.ts
@@ -17,7 +17,7 @@ const move = {
   range: 1,
   targetting: 'ground',
   get description() {
-    return `{{user}} dances to boost its Attack and Speed by 50% for the rest of the battle.`;
+    return `{{user}} dances to sharply boost its Attack and Speed PERMANENTLY.`;
   },
   getTarget(board: CombatScene['board'], myCoords: Coords) {
     return myCoords;
@@ -53,8 +53,8 @@ const move = {
           yoyo: true,
           onComplete: () => {
             user.changeStats({
-              attack: 1.5,
-              speed: 1.5,
+              attack: +2,
+              speed: +2,
             });
             onComplete();
           },

--- a/src/core/moves/kings-shield.ts
+++ b/src/core/moves/kings-shield.ts
@@ -23,7 +23,7 @@ const move = {
   get description() {
     return `{{user}} guards for 3 seconds, reducing incoming damage by ${this.damage.join(
       '/'
-    )}%. Afterwards, it lashes out, lowering Attack of nearby enemies by 25% and raising its own Attack and Speed by 25% for each enemy hit.`;
+    )}%. Afterwards, it lashes out, lowering Attack of nearby enemies for 8 seconds and raising its own Attack and Speed for each enemy hit.`;
   },
   getAOE({ x, y }: Coords) {
     return [
@@ -126,16 +126,22 @@ const move = {
 
         targets.forEach(target => {
           // reduce their attack
-          target.changeStats({
-            attack: 0.75,
-          });
+          target.changeStats(
+            {
+              attack: -1,
+            },
+            8000
+          );
         });
-        // increase self attack/speed based on targets hit, minimum 25%.
-        const targetsHit = Math.max(targets.length, 1);
-        user.changeStats({
-          attack: 1 + targetsHit * 0.25,
-          speed: 1 + targetsHit * 0.25,
-        });
+        // increase self attack/speed by one stack, or 2 if it hit 2+ targets
+        const targetsHit = targets.length >= 2 ? 2 : 1;
+        user.changeStats(
+          {
+            attack: targetsHit,
+            speed: targetsHit,
+          },
+          8000
+        );
       },
     });
   },

--- a/src/core/moves/mud-bomb.ts
+++ b/src/core/moves/mud-bomb.ts
@@ -23,7 +23,7 @@ const move = {
   get description() {
     return `{{user}} launches a hard-packed mud ball at single enemy, dealing ${this.damage.join(
       '/'
-    )} damage and slowing its Speed for 4 seconds. Adjacent enemies take half damage and aren't slowed.`;
+    )} damage and slowing its Speed for 5 seconds. Adjacent enemies take half damage and aren't slowed.`;
   },
   async use({
     board,
@@ -58,16 +58,13 @@ const move = {
           defenseStat: this.defenseStat,
         });
         scene.causeDamage(user, target, damage, { isAOE: true });
-        // fixme: make this a proper status
-        // reduce speed now, then restore speed after 5 seconds
-        target.changeStats({ speed: 0.5 });
+        target.changeStats({ speed: -1 }, 5000);
         scene.time.addEvent({
           callback: () => {
-            // clean up ground effect after slow wears off
+            // clean up ground effect when slow wears off
             bomb.destroy();
-            target.changeStats({ speed: 2 });
           },
-          delay: 4000,
+          delay: 5000,
         });
 
         // deal damage to possible adjacent targets

--- a/src/core/moves/quiver-dance.ts
+++ b/src/core/moves/quiver-dance.ts
@@ -16,7 +16,7 @@ const move = {
   range: 1,
   targetting: 'ground',
   get description() {
-    return `{{user}} dances to boost its Sp. Attack, Sp. Defense and Speed by 50% for the rest of the battle.`;
+    return `{{user}} dances to sharply raise its Sp. Attack, Sp. Defense and Speed PERMANENTLY.`;
   },
   getTarget(board: CombatScene['board'], myCoords: Coords) {
     return myCoords;
@@ -46,9 +46,9 @@ const move = {
         yoyo: true,
         onComplete: () => {
           user.changeStats({
-            specAttack: 1.5,
-            specDefense: 1.5,
-            speed: 1.5,
+            specAttack: +2,
+            specDefense: +2,
+            speed: +2,
           });
           onComplete();
         },

--- a/src/core/moves/shadow-ball.ts
+++ b/src/core/moves/shadow-ball.ts
@@ -22,7 +22,7 @@ const move = {
   get description() {
     return `{{user}} hurls a shadowy blob in a straight line, dealing ${this.damage.join(
       '/'
-    )} damage to every enemy hit and lowering their Sp. Defense by 50% until end of combat.`;
+    )} damage to every enemy hit and lowering their Sp. Defense for 10 seconds.`;
   },
   range: 1,
   use({
@@ -76,9 +76,12 @@ const move = {
               });
               scene.causeDamage(user, target, damage, { isAOE: true });
               // TODO: don't apply this more than once ever
-              target.changeStats({
-                specDefense: 0.5,
-              });
+              target.changeStats(
+                {
+                  specDefense: -1,
+                },
+                10000
+              );
               hasBeenHit[target.id] = true;
             });
           },

--- a/src/core/moves/therian-quake.ts
+++ b/src/core/moves/therian-quake.ts
@@ -28,7 +28,7 @@ const move = {
   get description() {
     return `{{user}} leaps into the air and transforms into its Therian Forme. Then it slams down, dealing ${this.damage.join(
       '/'
-    )} damage to a large area and Intimidating them, lowering their Attack by 25%. Does more damage when used in Therian Forme.`;
+    )} damage to a large area and Intimidating them, lowering their Attack for 8 seconds. Does more damage when used in Therian Forme.`;
   },
   range: 99,
   getTarget(board: CombatBoard, user: Coords) {
@@ -104,8 +104,8 @@ const move = {
             user.setTexture('landorustherian');
             user.play('landorustherian--down');
             user.changeStats({
-              attack: 1.25,
-              speed: 0.9,
+              attack: +1,
+              speed: -1,
             });
           } else {
             // if transformed, deal more damage
@@ -144,7 +144,7 @@ const move = {
                   scene.causeDamage(user, possibleTarget, damage, {
                     isAOE: true,
                   });
-                  possibleTarget.changeStats({ attack: 0.75 });
+                  possibleTarget.changeStats({ attack: -1 }, 8000);
                 }
               };
 

--- a/src/core/moves/venom-drench.ts
+++ b/src/core/moves/venom-drench.ts
@@ -24,7 +24,7 @@ const move = {
   get description() {
     return `{{user}} drenches all status-afflicted enemies in poison, dealing ${this.damage.join(
       '/'
-    )} damage and lowering a random stat by 25%. Poisoned enemies take double damage.`;
+    )} damage and PERMANENTLY lowering a random stat. Poisoned enemies take double damage.`;
   },
   range: 99,
   getTarget(board: CombatBoard, user: Coords) {
@@ -65,7 +65,7 @@ const move = {
         });
       const statToLower = stats[Math.floor(Math.random() * stats.length)];
       target.changeStats({
-        [statToLower]: 0.75,
+        [statToLower]: -1,
       });
 
       const damage = calculateDamage(user, target, {

--- a/src/core/moves/venom-drench.ts
+++ b/src/core/moves/venom-drench.ts
@@ -53,7 +53,14 @@ const move = {
           (pokemon.status.paralyse ||
             pokemon.status.poison ||
             pokemon.status.blind ||
-            pokemon.status.sleep)
+            pokemon.status.sleep ||
+            pokemon.status.ppReduction ||
+            pokemon.status.healReduction ||
+            pokemon.statChanges.attack < 0 ||
+            pokemon.statChanges.defense < 0 ||
+            pokemon.statChanges.specAttack < 0 ||
+            pokemon.statChanges.specDefense < 0 ||
+            pokemon.statChanges.speed < 0)
       );
 
     targets.forEach(target => {

--- a/src/math.helpers.ts
+++ b/src/math.helpers.ts
@@ -93,3 +93,7 @@ export function interpolateLineAOE(
     ? interpolateVertical(p1, p2, width)
     : interpolateVertical(p2, p1, width);
 }
+
+export function boundRange(value: number, min: number, max: number) {
+  return Math.max(Math.min(value, max), min);
+}


### PR DESCRIPTION
Currently, all stat changes are manually applied and are all multiplicative (with current stats).
This leads to a few problems:
- All stat changes are multiplicative, meaning stacking stat changes is super strong.
- Applying stat changes temporarily is kind of weird and requires odd math back and forth.

This commit refactors all the buffs into a stat "stage" system much like the main Pokemon games.
Each modifiable stat (attacks, defenses, speed) can be increased or decreased by up to 8 stages.
These stages provide an additive 25% multiplier or divisor to stats, ie. they look like this:

```
| stg |  +   |  %   |  +   |  %  |
|  0  | 4/4  | 100% | 4/4  | 100%|
|  1  | 5/4  | 125% | 4/5  | 80% |
|  2  | 6/4  | 150% | 4/6  | 66% |
|  3  | 7/4  | 175% | 4/7  | 57% |
|  4  | 8/4  | 200% | 4/8  | 50% |
|  5  | 9/4  | 225% | 4/9  | 44% |
|  6  | 10/4 | 250% | 4/10 | 40% |
|  7  | 11/4 | 275% | 4/11 | 36% |
|  8  | 12/4 | 300% | 4/12 | 33% |
```

One or two stages of buff are quite impactful, but the relative impact drops off as buffs stack higher.
That said, with existing sources of buffs/debuffs, it's pretty unlikely to stack past +4 or +5 for one stat.

To fit with the new system, almost all stat buffing moves and synergies have been adjusted.
Some are mostly unchanged (just switching to the stacking system, but others have had
durations added or stacks changed, to make up for gained/lost power through boost strength.