### PR TITLE
Improve AI

### DIFF
--- a/src/core/game.model.ts
+++ b/src/core/game.model.ts
@@ -239,7 +239,6 @@ when low on health.
       }
 
       const ppGain = tier === 1 ? 1 : tier === 2 ? 2 : 3;
-      console.log(isAttack, ppGain, attacker);
       if (isAttack) {
         attacker.addPP(ppGain);
         attacker.redrawBars();

--- a/src/objects/player.object.ts
+++ b/src/objects/player.object.ts
@@ -556,5 +556,16 @@ export class Player extends Phaser.GameObjects.GameObject {
     this.aiStrategy
       .decideSells?.(this)
       .forEach(toSell => this.sellPokemon(toSell));
+
+    // AI fallback: if doesn't want to sell anything AND board is full,
+    // just sell from the back of the sideboard
+    if (!this.canAddPokemonToSideboard()) {
+      console.warn("AI couldn't decide sells, selling anyway");
+      this.sideboard.slice(-3).forEach(toSell => {
+        if (toSell) {
+          this.sellPokemon(toSell);
+        }
+      });
+    }
   }
 }

--- a/src/objects/player.object.ts
+++ b/src/objects/player.object.ts
@@ -407,7 +407,6 @@ export class Player extends Phaser.GameObjects.GameObject {
     flatten(this.mainboard)
       .filter(isDefined)
       .forEach(pokemon => {
-        console.log(pokemon, counted);
         // ignore pokemon if counted already
         if (counted[pokemon.basePokemon.base]) {
           return;
@@ -446,7 +445,6 @@ export class Player extends Phaser.GameObjects.GameObject {
         }
         return b.category > a.category ? -1 : 1;
       });
-    console.log(this.synergyMap, this.synergies);
 
     // hide all synergy markers
     Object.values(this.synergyMarkers).forEach(marker => {


### PR DESCRIPTION
Currently, buy and sell logic is completely separate. AI will often buy very aggressively,
then fill their board up and sell half of the crap they just bought. This wastes time.

This commit improves the AI by consolidating the logic into one "want" system,
from which buy/sell priority is then calculated. The "want" logic is quite expansive
and hopefully covers most of the basic situations an AI will encounter.

This also tweaks the hard force AI generation to distinguish between "primary" and "splash" traits.
Every Pokemon of a primary trait will be prioritised, followed by splash traits, then random strong units.