### PR TITLE
(balance) Second balance pass

### DIFF
--- a/src/core/game.model.ts
+++ b/src/core/game.model.ts
@@ -568,7 +568,7 @@ Pokemon at the start of the round.
     displayName: 'Dragon: Sheer Force',
     description: `Boosts the power of Dragon-type moves.
 
- (3) - 75% more damage.`,
+ (3) - 50% more damage.`,
     thresholds: [3],
     calculateDamage({ attacker, baseAmount, side, count, flags }): number {
       const tier = getSynergyTier(this.thresholds, count);
@@ -625,7 +625,8 @@ Pokemon at the start of the round.
     description: `Innate: ALL Dark-type Pokemon teleport to the opposite
 side of the battlefield at the start of each round.
 
-Synergy: Dark-type Pokemon gain a critical hit ratio.
+Synergy: Dark-type Pokemon gain a critical hit ratio
+to both their attacks and their moves.
 
  (2) - 15% chance to deal 200% damage.
  (4) - 30% chance to deal 250% damage.

--- a/src/core/moves/brave-bird.ts
+++ b/src/core/moves/brave-bird.ts
@@ -10,7 +10,7 @@ const move = {
   displayName: 'Gale Wings',
   type: 'passive',
   flags: {},
-  damage: [30, 55, 90],
+  damage: [35, 55, 100],
   get description() {
     return `{{user}} raises its speed while above 50% health. While below 50% health, raises its Attack instead, and recovers ${this.damage.join(
       '/'

--- a/src/core/moves/dark-void.ts
+++ b/src/core/moves/dark-void.ts
@@ -22,11 +22,11 @@ const move = {
   defenseStat: 'specDefense',
   targetting: 'unit',
   // number of targets
-  damage: [2, 3, 8],
+  damage: [1, 2, 6],
   get description() {
     return `{{user}} puts the ${this.damage.join(
       '/'
-    )} enemies with highest HP to sleep for 4 seconds, and drains 10% of their HP/s while they sleep.`;
+    )} enemies with highest HP to sleep for 4 seconds, and drains 8% of their HP/s while they sleep.`;
   },
   range: 100,
   getTarget(board: CombatBoard, myCoords: Coords): Coords | undefined {
@@ -55,7 +55,7 @@ const move = {
           callback: () => {
             targets.forEach(target => {
               const damage = calculateDamage(user, target, {
-                damage: target.maxHP / 10,
+                damage: target.maxHP * 0.08,
                 defenseStat: this.defenseStat,
               });
               scene.causeDamage(user, target, damage, { isAOE: true });

--- a/src/core/moves/darkest-lariat.ts
+++ b/src/core/moves/darkest-lariat.ts
@@ -62,7 +62,7 @@ const move = {
           user,
           target,
           this.damage[user.basePokemon.stage - 1],
-          { isAOE: true }
+          { isAOE: true, canCrit: true }
         );
       }
     });

--- a/src/core/moves/dragon-dance.ts
+++ b/src/core/moves/dragon-dance.ts
@@ -13,11 +13,11 @@ const move = {
   type: 'active',
   // FIXME: Just disable mana after using move
   cost: 100,
-  startingPP: 92,
+  startingPP: 94,
   range: 1,
   targetting: 'ground',
   get description() {
-    return `{{user}} dances to sharply boost its Attack and Speed PERMANENTLY.`;
+    return `{{user}} dances to drastically boost its Attack and Speed PERMANENTLY.`;
   },
   getTarget(board: CombatScene['board'], myCoords: Coords) {
     return myCoords;
@@ -53,8 +53,8 @@ const move = {
           yoyo: true,
           onComplete: () => {
             user.changeStats({
-              attack: +2,
-              speed: +2,
+              attack: +3,
+              speed: +3,
             });
             onComplete();
           },

--- a/src/core/moves/dragon-darts.ts
+++ b/src/core/moves/dragon-darts.ts
@@ -19,7 +19,7 @@ const move = {
   type: 'active',
   cost: 5,
   startingPP: 2,
-  damage: [175, 300, 500],
+  damage: [200, 275, 400],
   defenseStat: 'defense',
   targetting: 'unit',
   get description() {
@@ -39,7 +39,7 @@ const move = {
 
     await Tweens.hop(scene, { targets: [user] });
 
-    // targets: X randomenemies, with X increasing each cast.
+    // targets: X random enemies, with X increasing each cast.
     user.consecutiveAttacks++;
     const enemies = flatten(board)
       .filter(isDefined)

--- a/src/core/moves/frenzy-plant.ts
+++ b/src/core/moves/frenzy-plant.ts
@@ -14,11 +14,11 @@ const move = {
   displayName: 'Frenzy Plant',
   type: 'active',
   cost: 22,
-  startingPP: 16,
+  startingPP: 18,
   range: 99,
   targetting: 'ground',
   // HP of the plant
-  damage: [150, 350, 600],
+  damage: [250, 400, 600],
   get description() {
     return `{{user}} summons a plant in a nearby square with its Attack and ${this.damage.join(
       '/'

--- a/src/core/moves/fury-cutter.ts
+++ b/src/core/moves/fury-cutter.ts
@@ -15,9 +15,9 @@ import * as Tweens from '../tweens';
 const move = {
   displayName: 'Fury Cutter',
   type: 'active',
-  cost: 4,
+  cost: 5,
   startingPP: 2,
-  damage: [200, 400, 999],
+  damage: [600, 1100, 999],
   defenseStat: 'defense',
   targetting: 'unit',
   get description() {
@@ -64,7 +64,7 @@ const move = {
               // damage increases by 50% each strike
               damage:
                 this.damage[user.basePokemon.stage - 1] *
-                2 ** user.consecutiveAttacks,
+                2 ** (user.consecutiveAttacks - 1),
               defenseStat: this.defenseStat,
             });
             scene.causeDamage(user, target, damage);

--- a/src/core/moves/ice-shard.ts
+++ b/src/core/moves/ice-shard.ts
@@ -19,7 +19,7 @@ const move = {
   type: 'active',
   cost: 4,
   startingPP: 2,
-  damage: [350, 650, 1400],
+  damage: [400, 550, 1400],
   defenseStat: 'defense',
   targetting: 'ground',
   get description() {
@@ -100,7 +100,7 @@ const move = {
               damage: this.damage[user.basePokemon.stage - 1],
               defenseStat: this.defenseStat,
             });
-            scene.causeDamage(user, target, damage, { canCrit: true });
+            scene.causeDamage(user, target, damage);
           },
           onComplete: () => {
             // reset to previous state

--- a/src/core/moves/kings-shield.ts
+++ b/src/core/moves/kings-shield.ts
@@ -19,11 +19,11 @@ const move = {
   startingPP: 28,
   range: 1,
   targetting: 'unit',
-  damage: [65, 80, 90],
+  damage: [70, 80, 90],
   get description() {
-    return `{{user}} guards for 3 seconds, reducing incoming damage by ${this.damage.join(
+    return `{{user}} guards for 2 seconds, reducing incoming damage by ${this.damage.join(
       '/'
-    )}%. Afterwards, it lashes out, lowering Attack of nearby enemies for 8 seconds and raising its own Attack and Speed for each enemy hit.`;
+    )}%. Afterwards, it lashes out, lowering Attack of nearby enemies for 8 seconds and raising its own Attack and Defense for each enemy hit.`;
   },
   getAOE({ x, y }: Coords) {
     return [
@@ -138,7 +138,8 @@ const move = {
         user.changeStats(
           {
             attack: targetsHit,
-            speed: targetsHit,
+            defense: targetsHit,
+            specDefense: targetsHit,
           },
           8000
         );

--- a/src/core/moves/leech-life.ts
+++ b/src/core/moves/leech-life.ts
@@ -10,9 +10,9 @@ import { Move, MoveConfig } from '../move.model';
 const move = {
   displayName: 'Leech Life',
   type: 'active',
-  cost: 14,
+  cost: 16,
   startingPP: 0,
-  damage: [250, 450, 660],
+  damage: [175, 300, 400],
   defenseStat: 'defense',
   targetting: 'unit',
   get description() {

--- a/src/core/moves/night-daze.ts
+++ b/src/core/moves/night-daze.ts
@@ -37,7 +37,7 @@ const move = {
           damage: this.damage[user.basePokemon.stage - 1],
           defenseStat: this.defenseStat,
         });
-        scene.causeDamage(user, target, damage, { isAOE: true });
+        scene.causeDamage(user, target, damage, { isAOE: true, canCrit: true });
         target.addStatus('blind', 3000);
         onComplete();
       },

--- a/src/core/moves/quiver-dance.ts
+++ b/src/core/moves/quiver-dance.ts
@@ -11,8 +11,8 @@ import * as Tweens from '../tweens';
 const move = {
   displayName: 'Quiver Dance',
   type: 'active',
-  cost: 100,
-  startingPP: 90,
+  cost: 99,
+  startingPP: 88,
   range: 1,
   targetting: 'ground',
   get description() {

--- a/src/core/moves/razor-wind.ts
+++ b/src/core/moves/razor-wind.ts
@@ -124,7 +124,10 @@ const move = {
                   damage: dph,
                   defenseStat: this.defenseStat,
                 });
-                scene.causeDamage(user, pokemon, damage, { isAOE: true });
+                scene.causeDamage(user, pokemon, damage, {
+                  isAOE: true,
+                  canCrit: true,
+                });
               }
             });
             if (timer.repeatCount === 0) {

--- a/src/core/moves/shadow-ball.ts
+++ b/src/core/moves/shadow-ball.ts
@@ -16,13 +16,13 @@ const move = {
   type: 'active',
   cost: 20,
   startingPP: 10,
-  damage: [300, 550, 800],
+  damage: [350, 550, 900],
   defenseStat: 'specDefense',
   targetting: 'unit',
   get description() {
     return `{{user}} hurls a shadowy blob in a straight line, dealing ${this.damage.join(
       '/'
-    )} damage to every enemy hit and lowering their Sp. Defense for 10 seconds.`;
+    )} damage to every enemy hit and sharply lowering their Sp. Defense for 8 seconds.`;
   },
   range: 1,
   use({
@@ -78,9 +78,9 @@ const move = {
               // TODO: don't apply this more than once ever
               target.changeStats(
                 {
-                  specDefense: -1,
+                  specDefense: -2,
                 },
-                10000
+                8000
               );
               hasBeenHit[target.id] = true;
             });

--- a/src/core/moves/shell-trap.ts
+++ b/src/core/moves/shell-trap.ts
@@ -21,8 +21,8 @@ const move = {
   startingPP: 16,
   range: 1,
   targetting: 'ground',
-  damage: [100, 175, 300],
-  percentReflect: [10, 25, 776],
+  damage: [150, 200, 300],
+  percentReflect: [15, 25, 776],
   defenseStat: 'specDefense',
   get description() {
     return `{{user}} shields itself, reducing all incoming damage by 40% for 6 seconds. When hit by an attack, {{user}} erupts to deal ${this.damage.join(

--- a/src/core/moves/stone-edge.ts
+++ b/src/core/moves/stone-edge.ts
@@ -78,7 +78,10 @@ const move = {
                 damage: realBaseDamage,
                 defenseStat: this.defenseStat,
               });
-              scene.causeDamage(user, pokemon, damage, { isAOE: true });
+              scene.causeDamage(user, pokemon, damage, {
+                isAOE: true,
+                canCrit: true,
+              });
             });
           },
           delay: animations['stone-edge-shoot'].duration / 2,

--- a/src/core/moves/teleport.ts
+++ b/src/core/moves/teleport.ts
@@ -12,12 +12,12 @@ import { Move, MoveConfig } from '../move.model';
 const move = {
   displayName: 'Teleport',
   type: 'active',
-  cost: 24,
+  cost: 28,
   startingPP: 4,
   range: 1,
   targetting: 'ground',
   // actually heal %
-  damage: [25, 40, 50],
+  damage: [15, 20, 33],
   get description() {
     return `{{user}} teleports to a random spot on the grid, healing for ${this.damage.join(
       '/'

--- a/src/core/moves/twineedle.ts
+++ b/src/core/moves/twineedle.ts
@@ -8,7 +8,7 @@ import { Move, MoveConfig } from '../move.model';
 const move = {
   displayName: 'Twineedle',
   type: 'active',
-  // slight hack: this move is a move that "casts" every attack instead of trigering
+  // slight hack: this move is a move that "casts" every attack instead of triggering
   cost: 0,
   startingPP: 0,
   range: 3,

--- a/src/core/moves/volt-tackle.ts
+++ b/src/core/moves/volt-tackle.ts
@@ -19,7 +19,7 @@ const move = {
   type: 'active',
   cost: 10,
   startingPP: 4,
-  damage: [400, 650, 800],
+  damage: [400, 650, 900],
   defenseStat: 'defense',
   targetting: 'unit',
   get description() {

--- a/src/core/moves/zap-cannon.ts
+++ b/src/core/moves/zap-cannon.ts
@@ -21,7 +21,7 @@ const move = {
   type: 'active',
   cost: 28,
   startingPP: 14,
-  damage: [400, 750, 1100],
+  damage: [450, 850, 1100],
   defenseStat: 'specDefense',
   targetting: 'ground',
   get description() {


### PR DESCRIPTION
- Shift power from Weavile into other Dark types by giving them move crit
- Slight nerfs to outliers (Kadabra, Zubat, 2* Drakloak, Darkrai, Larvesta)
- Buffs to Honedge and Gastly to make up for 2x sweeper nerf (for Ghost Sweepers)
- Slight 3* buffs for Revenge Killers (Talonflame + Raichu)
- More buffs to crap mons (Gyarados, Turtonator, Bulbasaur)
- Fixes a bug where Scizor did double damage, but buffs to compensate