### PR TITLE
Revamp water-type synergy

### DIFF
--- a/src/core/game.model.spec.ts
+++ b/src/core/game.model.spec.ts
@@ -165,6 +165,7 @@ describe('individual synergy effects', () => {
       ];
 
       waterTypes.forEach((mon) => {
+        // HP and PP so we can know the heal/PP up worked
         mon.currentHP = 1;
         mon.currentPP = 0;
       });

--- a/src/core/game.model.ts
+++ b/src/core/game.model.ts
@@ -356,24 +356,58 @@ more damage, and heal them on hit.
   },
   water: {
     category: 'water',
-    displayName: 'Water: Aqua Ring',
-    description: `All Pokemon gain extra PP on hit.
+    displayName: 'Water: Rain Dance',
+    description: `Rain falls every 12 seconds, granting
+effects to all your Water-type Pokemon
+based on the ones you have fielded.
 
- (2) - 1 extra PP
- (4) - 2 extra PP
- (6) - 3 extra PP`,
-    thresholds: [2, 4, 6],
-    onHit({ attacker, flags: { isAttack }, count }) {
+Rain falls faster for each additional
+Water-type you have.
+
+  Magikarp: +1 to Speed.
+  Mudkip: Restore 10% of HP.
+  Mareanie: +1 to Defense.
+  Rotom-Wash: Gain 2 PP.
+  Lapras: +1 to Special Defense.
+`,
+    thresholds: [1, 2, 3, 4, 5],
+    onTimer({ board, side, count, time }) {
       const tier = getSynergyTier(this, count);
       if (tier === 0) {
         return;
       }
 
-      const ppGain = tier === 1 ? 1 : tier === 2 ? 2 : 3;
-      if (isAttack) {
-        attacker.addPP(ppGain);
-        attacker.redrawBars();
+      const interval = 12 - tier;
+      if (time % interval !== 0) {
+        return;
       }
+
+      const waterTypes = flatten(board)
+        .filter(isDefined)
+        .filter((pokemon) => pokemon.side === side)
+        .filter((pokemon) => pokemon.basePokemon.categories.includes('water'));
+
+      const inTeam = Object.fromEntries(
+        waterTypes.map((p) => [p.basePokemon.base, true])
+      );
+
+      waterTypes.forEach((pokemon) => {
+        if (inTeam['magikarp']) {
+          pokemon.changeStats({ speed: +1 });
+        }
+        if (inTeam['mudkip']) {
+          pokemon.heal(pokemon.maxHP * 0.1);
+        }
+        if (inTeam['mareanie']) {
+          pokemon.changeStats({ defense: +1 });
+        }
+        if (inTeam['rotom-wash']) {
+          pokemon.addPP(2);
+        }
+        if (inTeam['lapras']) {
+          pokemon.changeStats({ specDefense: +1 });
+        }
+      });
     },
   },
   flying: {

--- a/src/core/game.model.ts
+++ b/src/core/game.model.ts
@@ -401,7 +401,7 @@ Water-type you have.
         if (inTeam['mareanie']) {
           pokemon.changeStats({ defense: +1 });
         }
-        if (inTeam['rotom-wash']) {
+        if (inTeam['rotom_wash']) {
           pokemon.addPP(2);
         }
         if (inTeam['lapras']) {
@@ -496,16 +496,9 @@ recovered, split among all enemies.
         (pokemon) => pokemon && pokemon?.side !== side
       );
       const damage = Math.floor((healingDone * healPerc) / targets.length);
-      flatten(board)
-        .filter(isDefined)
-        .forEach((pokemon) => {
-          if (pokemon.side !== side) {
-            // TODO: do this damage via combat scene so the damage gets tracked in graphs
-            pokemon.takeDamage(damage, {
-              tint: 0x00ff00, // Slight green tint
-            });
-          }
-        });
+      targets.forEach((target) => {
+        target?.takeDamage(damage);
+      });
       scene.data.set(this.category, 0);
     },
   },

--- a/src/core/moves/purifying-salt.ts
+++ b/src/core/moves/purifying-salt.ts
@@ -1,7 +1,6 @@
 import { Coords } from '../../scenes/game/combat/combat.helpers';
 import { CombatBoard } from '../../scenes/game/combat/combat.scene';
 import { Move, MoveConfig } from '../move.model';
-import { NEGATIVE_STATUS } from '../status.model';
 import * as Tweens from '../tweens';
 
 const healing = [300, 600, 1000];
@@ -32,16 +31,7 @@ export const purifyingSalt = {
       targets: [user],
       onComplete: () => {
         user.heal(healing[user.basePokemon.stage - 1]);
-        NEGATIVE_STATUS.forEach((status) => {
-          if (user.status[status]) {
-            delete user.status[status];
-          }
-        });
-        Object.entries(user.effects).forEach(([key, value]) => {
-          if (value.effect.isNegative) {
-            delete user.effects[key];
-          }
-        });
+        user.purgeNegativeStatuses();
         onComplete();
       },
     });

--- a/src/objects/pokemon.object.ts
+++ b/src/objects/pokemon.object.ts
@@ -826,6 +826,20 @@ export class PokemonObject extends Phaser.Physics.Arcade.Sprite {
     this.redrawBars();
   }
 
+  public purgeNegativeStatuses() {
+    NEGATIVE_STATUS.forEach((status) => {
+      if (this.status[status]) {
+        delete this.status[status];
+      }
+    });
+    Object.entries(this.effects).forEach(([key, value]) => {
+      if (value.effect.isNegative) {
+        delete this.effects[key];
+      }
+    });
+    this.redrawBars();
+  }
+
   public canUseMove(): boolean {
     if (this.basePokemon.move?.type !== 'active') {
       return false;

--- a/src/testing/helpers.ts
+++ b/src/testing/helpers.ts
@@ -101,7 +101,10 @@ export function startTestingCombatScene(
 /**
  * Advance a scene's clock by a given amount of time.
  *
- * Triggers ALL events that would occur in between.
+ * Triggers all clock events that would occur in between.
+ *
+ * NOTE: This does NOT trigger combat `onTimer` events with all the times in the delta.
+ * If you want to trigger an `onTimer` event, always `tick()` directly to when it would fire.
  */
 export function tick(scene: Phaser.Scene, delta: number = 1000) {
   const initialTime = scene.time.now;
@@ -114,7 +117,9 @@ export function tick(scene: Phaser.Scene, delta: number = 1000) {
   // but the scene "timer" is stored statically, so they're all called
   // with the same "time". This results in onTimers triggering multiple times.
   // To work around this, we need to update up to t-1 second first, then do the rest.
-
+  //
+  // Note that this will still NOT correctly trigger combat onTimer events in between.
+  // It will only trigger them at t-1 and t seconds (and incorrectly trigger a lot at t-1).
   const firstDelta = delta - 1000;
   if (firstDelta > 0) {
     // Update the scene first


### PR DESCRIPTION
This diff revamps the Water-type synergy to be based on Rain Dance and provide buffs to water-types over time. It also refactors `purgeNegativeStatuses` into a helper function, though it's not used by the new synergy.

Tests are provided + some fixes to timer-based tests.