### PR TITLE
Decouple level from board size

### DIFF
--- a/src/objects/ai/ai.ts
+++ b/src/objects/ai/ai.ts
@@ -26,9 +26,9 @@ function genericPrioritiseBoard(
   sortFn = (a: PokemonObject, b: PokemonObject) =>
     getPokemonStrength(b.basePokemon) - getPokemonStrength(a.basePokemon)
 ): PokemonObject[] {
-  // Shortcut: For level 1-2, just play strongest units.
+  // Shortcut: For board size <= 2 just play strongest units.
   // ignore any specialised ordering logic as well.
-  if (player.level <= 2) {
+  if (player.teamSize <= 2) {
     return [...flatten(player.mainboard), ...player.sideboard]
       .filter(isDefined)
       .sort(
@@ -62,7 +62,7 @@ function genericPrioritiseBoard(
       // the max possible count for that synergy is still 3
       allSynergies[category] = Math.min(
         (allSynergies[category] ?? 0) + 1,
-        player.level
+        player.teamSize
       );
     });
     deduplicatedPokemon.push(pokemon);
@@ -122,7 +122,7 @@ function genericPrioritiseBoard(
   //  2. Any units that boost the tier of a splash trait
   //  3. The strongest unit out of the rest
   // ==========================================================
-  while (currentBoard.length < player.level) {
+  while (currentBoard.length < player.teamSize) {
     if (deduplicatedPokemon.length === 0) {
       console.warn('Not enough deduplicated Pokemon to build a full board!');
       break;
@@ -273,7 +273,7 @@ function decideWant(
     // since we're unlikely to put them on the board or level them up further.
     if (
       strict &&
-      player.level === 6 &&
+      player.teamSize === 6 &&
       (totalCopies[pokemon.base] ?? 0) >= 3 &&
       !allBoardUnits.includes(pokemon.name)
     ) {
@@ -285,7 +285,7 @@ function decideWant(
     // level 3 start ignoring 1* 1-costs, ramping up to selling excess 2/3 costs
     if (
       strict &&
-      getPokemonStrength(pokemon) <= player.level + 1 &&
+      getPokemonStrength(pokemon) <= player.teamSize + 1 &&
       rerollTarget !== pokemon.base
     ) {
       return false;
@@ -302,7 +302,7 @@ function decideWant(
       // only flex for forced comps with no explicit splash
       (!forced || forced.length === 1) &&
       // only hold extra units when can still level up
-      player.level < 6 &&
+      player.teamSize < 6 &&
       // don't pick up if we already have a candidate for next board unit
       !strongNextUnit &&
       pokemon.categories.some(
@@ -328,7 +328,7 @@ function decideWant(
     // YES if can improve our active on-board synergies
     // and we don't have enough units on bench or some of them are weak
     if (
-      (potentialNextUnits.length < 6 - player.level ||
+      (potentialNextUnits.length < 6 - player.teamSize ||
         potentialNextUnits.some(
           (potentialUnit) => potentialUnit.basePokemon.tier < pokemon.tier
         )) &&

--- a/src/objects/ai/ai.ts
+++ b/src/objects/ai/ai.ts
@@ -57,8 +57,8 @@ function genericPrioritiseBoard(
     }
 
     pokemon.basePokemon.categories.forEach((category) => {
-      // add 1 to the synergy, capping out at player level
-      // eg. if level 3 and have 4 of a synergy on bench,
+      // add 1 to the synergy, capping out at current max team size
+      // eg. if 3 units on board and have 4 of a synergy on bench,
       // the max possible count for that synergy is still 3
       allSynergies[category] = Math.min(
         (allSynergies[category] ?? 0) + 1,

--- a/src/objects/player.object.ts
+++ b/src/objects/player.object.ts
@@ -1,6 +1,7 @@
 import { Category, getSynergyTier, synergyData } from '../core/game.model';
 import { pokemonData, PokemonName } from '../core/pokemon.model';
 import { flatten, isDefined } from '../helpers';
+import { boundRange } from '../math.helpers';
 import { CombatBoard } from '../scenes/game/combat/combat.scene';
 import {
   BOARD_WIDTH,
@@ -40,7 +41,7 @@ export class Player extends Phaser.GameObjects.GameObject {
    * "Dex EXP"
    * Used to level up. Thresholds are determined by the game mode.
    */
-  exp: number;
+  exp = 0;
   gold: number;
   hp = 100;
   /** Consecutive win/loss streak */
@@ -91,7 +92,9 @@ export class Player extends Phaser.GameObjects.GameObject {
   private visible: boolean;
 
   get teamSize(): number {
-    return this.gameData.levels[this.level].teamSize;
+    return this.gameData.levels[
+      boundRange(this.level, 0, this.gameData.levels.length - 1)
+    ].teamSize;
   }
 
   constructor(

--- a/src/objects/player.object.ts
+++ b/src/objects/player.object.ts
@@ -602,7 +602,7 @@ export class Player extends Phaser.GameObjects.GameObject {
     const spaceInRow = [0, 0, 0, 0, 0, 0];
     boardOrder.forEach((selectedPokemon, index) => {
       if (index < this.teamSize) {
-        // if index < level, we have room on the board
+        // if index < board size, we have room on the board
 
         // pick a spot for them based on their range.
         // ranged units go in back row, melee in front

--- a/src/scenes/game/game.helpers.spec.ts
+++ b/src/scenes/game/game.helpers.spec.ts
@@ -1,0 +1,12 @@
+import { describe, expect, test } from '@jest/globals';
+import { DEFAULT_LEVELS } from './game.helpers';
+
+describe('game modes', () => {
+  describe('level shop odds', () => {
+    DEFAULT_LEVELS.forEach(({ shopOdds }, level) => {
+      test(`default odds at level ${level} should sum to 100%`, () => {
+        expect(shopOdds.reduce((acc, curr) => acc + curr, 0)).toBe(100);
+      });
+    });
+  });
+});

--- a/src/scenes/game/game.helpers.ts
+++ b/src/scenes/game/game.helpers.ts
@@ -1,6 +1,6 @@
 import { getSynergyTier, synergyData } from '../../core/game.model';
 import { getPokemonStrength } from '../../core/pokemon.helpers';
-import { PokemonName } from '../../core/pokemon.model';
+import { Pokemon, PokemonName } from '../../core/pokemon.model';
 import { flatten, isDefined } from '../../helpers';
 import { Player } from '../../objects/player.object';
 import { Coords } from './combat/combat.helpers';
@@ -41,33 +41,41 @@ export interface Level {
 /**
  * Default levelling cadence
  *
- * Odd levels = new tier of Pokemon unlocked.
+ * Odd levels = team size increase / slight shop odds change
  *
- * Even levels = team size increase.
+ * Even levels = new tier of Pokemon / significant shop odds change
  */
-const DEFAULT_LEVELS: Level[] = [
+export const DEFAULT_LEVELS: Level[] = [
   { teamSize: 2, expToLevel: 2, shopOdds: [0, 80, 20, 0, 0, 0] },
   { teamSize: 3, expToLevel: 2, shopOdds: [0, 75, 25, 0, 0, 0] },
   { teamSize: 3, expToLevel: 6, shopOdds: [0, 55, 30, 15, 0, 0] },
   { teamSize: 4, expToLevel: 14, shopOdds: [0, 45, 35, 20, 0, 0] },
-  { teamSize: 4, expToLevel: 14, shopOdds: [0, 32, 40, 24, 3, 0] },
-  { teamSize: 5, expToLevel: 26, shopOdds: [0, 27, 34, 28, 11, 0] },
-  { teamSize: 5, expToLevel: 26, shopOdds: [0, 21, 27, 35, 15, 1] },
-  { teamSize: 6, expToLevel: 36, shopOdds: [0, 16, 23, 32, 21, 8] },
+  { teamSize: 4, expToLevel: 14, shopOdds: [0, 33, 40, 24, 3, 0] },
+  { teamSize: 5, expToLevel: 26, shopOdds: [0, 28, 36, 28, 8, 0] },
+  { teamSize: 5, expToLevel: 26, shopOdds: [0, 21, 26, 35, 16, 2] },
+  { teamSize: 6, expToLevel: 36, shopOdds: [0, 17, 23, 33, 21, 6] },
   { teamSize: 6, expToLevel: 54, shopOdds: [0, 10, 16, 26, 34, 14] },
   {
     teamSize: 6,
     bonusSlots: 1,
     expToLevel: 44,
-    shopOdds: [0, 8, 14, 24, 32, 22],
+    shopOdds: [0, 8, 14, 25, 33, 20],
   },
   {
     teamSize: 6,
     bonusSlots: 1,
     expToLevel: 0,
-    shopOdds: [0, 5, 10, 15, 30, 40],
+    shopOdds: [0, 5, 10, 20, 30, 35],
   },
 ];
+
+export const DEFAULT_SHOP_POOL = {
+  1: 27,
+  2: 24,
+  3: 21,
+  4: 18,
+  5: 15,
+};
 
 /**
  * A representation of a game mode, with all its options
@@ -82,6 +90,12 @@ export interface GameMode {
    * Levels start at 0 for index convenience.
    */
   readonly levels: Level[];
+  /**
+   * The number of Pokemon in the shop pool for each tier.
+   */
+  readonly shopPool: {
+    [tier in Pokemon['tier']]: number;
+  };
   /** Starting player gold */
   readonly startingGold: number;
   /** Whether the game mode has opposing players */
@@ -177,6 +191,7 @@ export function getHyperRollGameMode(): GameMode {
       { rounds: 5, damage: () => 99, gold: () => 0 },
     ],
     levels: DEFAULT_LEVELS,
+    shopPool: DEFAULT_SHOP_POOL,
     startingGold: 10,
   };
 }
@@ -186,6 +201,13 @@ export function getDebugGameMode(): GameMode {
     name: 'debug',
     stages: [{ rounds: 99, damage: () => 1, gold: () => 50 }],
     levels: [{ teamSize: 6, expToLevel: 0, shopOdds: [0, 1, 1, 1, 1, 1] }],
+    shopPool: {
+      1: 50,
+      2: 50,
+      3: 50,
+      4: 50,
+      5: 50,
+    },
     startingGold: 50,
   };
 }

--- a/src/scenes/game/game.helpers.ts
+++ b/src/scenes/game/game.helpers.ts
@@ -24,6 +24,51 @@ export function getCoordinatesForMainboard({ x, y }: Coords): Coords {
   };
 }
 
+export interface Level {
+  /** Amount of Pokemon that can be placed on the board at this level */
+  readonly teamSize: number;
+  /** Amount of bonus slots available (Pokemon applies traits but doesn't join combat) */
+  readonly bonusSlots?: number;
+  /** Amount of experienced needed to reach next level. Set this to 0 if there's no next level */
+  readonly expToLevel: number;
+  /**
+   * Odds of each tier of Pokemon in the shop at this level.
+   * 6-element array to allow for direct indexing using Pokemon tier.
+   **/
+  readonly shopOdds: [0, number, number, number, number, number];
+}
+
+/**
+ * Default levelling cadence
+ *
+ * Odd levels = new tier of Pokemon unlocked.
+ *
+ * Even levels = team size increase.
+ */
+const DEFAULT_LEVELS: Level[] = [
+  { teamSize: 2, expToLevel: 2, shopOdds: [0, 80, 20, 0, 0, 0] },
+  { teamSize: 3, expToLevel: 2, shopOdds: [0, 75, 25, 0, 0, 0] },
+  { teamSize: 3, expToLevel: 6, shopOdds: [0, 55, 30, 15, 0, 0] },
+  { teamSize: 4, expToLevel: 14, shopOdds: [0, 45, 35, 20, 0, 0] },
+  { teamSize: 4, expToLevel: 14, shopOdds: [0, 32, 40, 24, 3, 0] },
+  { teamSize: 5, expToLevel: 26, shopOdds: [0, 27, 34, 28, 11, 0] },
+  { teamSize: 5, expToLevel: 26, shopOdds: [0, 20, 27, 35, 15, 2] },
+  { teamSize: 6, expToLevel: 36, shopOdds: [0, 16, 23, 33, 21, 7] },
+  { teamSize: 6, expToLevel: 54, shopOdds: [0, 10, 16, 26, 34, 14] },
+  {
+    teamSize: 6,
+    bonusSlots: 1,
+    expToLevel: 44,
+    shopOdds: [0, 8, 14, 24, 32, 22],
+  },
+  {
+    teamSize: 6,
+    bonusSlots: 1,
+    expToLevel: 0,
+    shopOdds: [0, 5, 10, 15, 30, 40],
+  },
+];
+
 /**
  * A representation of a game mode, with all its options
  */
@@ -32,14 +77,13 @@ export interface GameMode {
   readonly name: string;
   /** The set of stages (which are made up of rounds) */
   readonly stages: Stage[];
-  /** Rates of each tier of Pokemon in the shop at each player level */
-  readonly shopRates: {
-    // 6-element array to allow for 1-indexing using Pokemon tiers.
-    [k: string]: [number, number, number, number, number, number];
-  };
+  /**
+   * Details of each player level.
+   * Levels start at 0 for index convenience.
+   */
+  readonly levels: Level[];
+  /** Starting player gold */
   readonly startingGold: number;
-  /** Whether players can spend gold on exp to level up */
-  readonly levelCosts?: number[];
   /** Whether the game mode has opposing players */
   readonly isPVE?: boolean;
 }
@@ -99,48 +143,50 @@ export function getHyperRollGameMode(): GameMode {
         neutralRounds: {
           1: {
             name: 'Wild Rattata',
+            board: [{ name: 'neutral_only_rattata', location: { x: 3, y: 3 } }],
+          },
+        },
+      },
+      {
+        rounds: 1,
+        damage: () => 5,
+        gold: goldGainFunc(5),
+        autolevel: 1,
+        neutralRounds: {
+          1: {
+            name: 'Wild Rattata',
             board: [
               { name: 'neutral_only_rattata', location: { x: 1, y: 3 } },
+              { name: 'neutral_only_rattata', location: { x: 3, y: 3 } },
               { name: 'neutral_only_rattata', location: { x: 4, y: 3 } },
+              { name: 'neutral_only_rattata', location: { x: 6, y: 3 } },
             ],
           },
         },
       },
-      { rounds: 2, damage: () => 10, autolevel: 2, gold: goldGainFunc(6) },
-      { rounds: 3, damage: () => 10, autolevel: 3, gold: goldGainFunc(7) },
-      { rounds: 3, damage: () => 15, autolevel: 4, gold: goldGainFunc(7) },
-      { rounds: 4, damage: () => 15, autolevel: 5, gold: goldGainFunc(8) },
-      { rounds: 10, damage: () => 20, autolevel: 6, gold: goldGainFunc(8) },
+      { rounds: 1, damage: () => 5, autolevel: 2, gold: goldGainFunc(5) },
+      { rounds: 2, damage: () => 10, autolevel: 3, gold: goldGainFunc(6) },
+      { rounds: 2, damage: () => 10, autolevel: 4, gold: goldGainFunc(6) },
+      { rounds: 3, damage: () => 15, autolevel: 5, gold: goldGainFunc(7) },
+      { rounds: 3, damage: () => 15, autolevel: 6, gold: goldGainFunc(8) },
+      { rounds: 4, damage: () => 20, autolevel: 7, gold: goldGainFunc(8) },
+      { rounds: 4, damage: () => 20, autolevel: 8, gold: goldGainFunc(8) },
+      { rounds: 5, damage: () => 25, autolevel: 9, gold: goldGainFunc(9) },
+      { rounds: 5, damage: () => 25, autolevel: 10, gold: goldGainFunc(9) },
       // last section is sudden death. 99 damage, no gold - game must end!
       { rounds: 5, damage: () => 99, gold: () => 0 },
     ],
-    shopRates: {
-      1: [0, 100, 0, 0, 0, 0],
-      2: [0, 70, 30, 0, 0, 0],
-      3: [0, 50, 35, 15, 0, 0],
-      4: [0, 30, 35, 28, 7, 0],
-      5: [0, 19, 30, 35, 15, 1],
-      6: [0, 15, 25, 30, 23, 7],
-    },
+    levels: DEFAULT_LEVELS,
     startingGold: 10,
-    levelCosts: undefined,
   };
 }
 
 export function getDebugGameMode(): GameMode {
   return {
     name: 'debug',
-    stages: [{ rounds: 99, damage: () => 1, gold: () => 50, autolevel: 6 }],
-    shopRates: {
-      1: [0, 1, 1, 1, 1, 1],
-      2: [0, 1, 1, 1, 1, 1],
-      3: [0, 1, 1, 1, 1, 1],
-      4: [0, 1, 1, 1, 1, 1],
-      5: [0, 1, 1, 1, 1, 1],
-      6: [0, 1, 1, 1, 1, 1],
-    },
+    stages: [{ rounds: 99, damage: () => 1, gold: () => 50 }],
+    levels: [{ teamSize: 6, expToLevel: 0, shopOdds: [0, 1, 1, 1, 1, 1] }],
     startingGold: 50,
-    levelCosts: undefined,
   };
 }
 

--- a/src/scenes/game/game.helpers.ts
+++ b/src/scenes/game/game.helpers.ts
@@ -170,10 +170,10 @@ export function getHyperRollGameMode(): GameMode {
           1: {
             name: 'Wild Rattata',
             board: [
-              { name: 'neutral_only_rattata', location: { x: 1, y: 3 } },
+              { name: 'neutral_only_rattata', location: { x: 0, y: 4 } },
+              { name: 'neutral_only_rattata', location: { x: 2, y: 3 } },
               { name: 'neutral_only_rattata', location: { x: 3, y: 3 } },
-              { name: 'neutral_only_rattata', location: { x: 4, y: 3 } },
-              { name: 'neutral_only_rattata', location: { x: 6, y: 3 } },
+              { name: 'neutral_only_rattata', location: { x: 5, y: 4 } },
             ],
           },
         },

--- a/src/scenes/game/game.helpers.ts
+++ b/src/scenes/game/game.helpers.ts
@@ -52,8 +52,8 @@ const DEFAULT_LEVELS: Level[] = [
   { teamSize: 4, expToLevel: 14, shopOdds: [0, 45, 35, 20, 0, 0] },
   { teamSize: 4, expToLevel: 14, shopOdds: [0, 32, 40, 24, 3, 0] },
   { teamSize: 5, expToLevel: 26, shopOdds: [0, 27, 34, 28, 11, 0] },
-  { teamSize: 5, expToLevel: 26, shopOdds: [0, 20, 27, 35, 15, 2] },
-  { teamSize: 6, expToLevel: 36, shopOdds: [0, 16, 23, 33, 21, 7] },
+  { teamSize: 5, expToLevel: 26, shopOdds: [0, 21, 27, 35, 15, 1] },
+  { teamSize: 6, expToLevel: 36, shopOdds: [0, 16, 23, 32, 21, 8] },
   { teamSize: 6, expToLevel: 54, shopOdds: [0, 10, 16, 26, 34, 14] },
   {
     teamSize: 6,

--- a/src/scenes/game/game.scene.ts
+++ b/src/scenes/game/game.scene.ts
@@ -221,7 +221,8 @@ export class GameScene extends Phaser.Scene {
     this.pool = new ShopPool(
       mode.levels.map((level) => level.shopOdds),
       buyablePokemon,
-      pokemonData
+      pokemonData,
+      this.gameMode.shopPool
     );
     this.currentStage = 0;
     this.currentRound = 1;

--- a/src/scenes/game/game.scene.ts
+++ b/src/scenes/game/game.scene.ts
@@ -218,7 +218,11 @@ export class GameScene extends Phaser.Scene {
       .setVisible(false);
 
     this.gameMode = mode;
-    this.pool = new ShopPool(mode.shopRates, buyablePokemon, pokemonData);
+    this.pool = new ShopPool(
+      mode.levels.map((level) => level.shopOdds),
+      buyablePokemon,
+      pokemonData
+    );
     this.currentStage = 0;
     this.currentRound = 1;
     this.currentRoundText = this.add
@@ -238,8 +242,7 @@ export class GameScene extends Phaser.Scene {
       new Player(this, 'You', 720, 100, {
         pool: this.pool,
         isHumanPlayer: true,
-        initialLevel: this.gameMode.stages[this.currentStage].autolevel,
-        startingGold: this.gameMode.startingGold,
+        gameData: this.gameMode,
       })
     );
     this.players = [this.humanPlayer];
@@ -255,8 +258,7 @@ export class GameScene extends Phaser.Scene {
             new Player(this, name, 720, 130 + 30 * index, {
               pool: this.pool,
               isHumanPlayer: false,
-              initialLevel: this.gameMode.stages[this.currentStage].autolevel,
-              startingGold: this.gameMode.startingGold,
+              gameData: this.gameMode,
             })
           )
         ),
@@ -722,7 +724,7 @@ export class GameScene extends Phaser.Scene {
           flatten(this.currentVisiblePlayer.mainboard).filter((v) =>
             isDefined(v)
           ).length
-        }/${this.currentVisiblePlayer.level}`
+        }/${this.currentVisiblePlayer.teamSize}`
       );
   }
 
@@ -763,7 +765,8 @@ export class GameScene extends Phaser.Scene {
     const player = new Player(this, round.name, -100, -100, {
       pool: this.pool,
       isHumanPlayer: false,
-      initialLevel: round.board.length,
+      // FIXME: This limits the maximum size of a team for neutral rounds as well...
+      gameData: this.gameMode,
     });
     round.board.forEach((pokemon) => {
       player.addPokemonToSideboard(pokemon.name);

--- a/src/scenes/game/shop.helpers.spec.ts
+++ b/src/scenes/game/shop.helpers.spec.ts
@@ -25,14 +25,12 @@ describe('shop rerolling', () => {
   test('should roll and remove stuff from the pool', () => {
     Math.random = alwaysFirst;
     const pool = new ShopPool(
-      {
-        1: [0, 1, 0, 0, 0, 0],
-      },
+      [[0, 1, 0, 0, 0, 0]],
       ['litwick'],
       { litwick: { tier: 1, stage: 1, base: 'litwick' } } as any,
       { 1: 5, 2: 0, 3: 0, 4: 0, 5: 0 }
     );
-    expect(pool.reroll({ level: 1 } as Player)).toEqual([
+    expect(pool.reroll({ level: 0 } as Player)).toEqual([
       'litwick',
       'litwick',
       'litwick',
@@ -45,12 +43,12 @@ describe('shop rerolling', () => {
   test('should roll from the correct level for the player', () => {
     Math.random = alwaysFirst;
     const pool = new ShopPool(
-      {
-        // level 1: only roll tier 1s
-        1: [0, 1, 0, 0, 0, 0],
-        // level 2: only roll tier 2s
-        2: [0, 0, 1, 0, 0, 0],
-      },
+      [
+        // level 0: only roll tier 1s
+        [0, 1, 0, 0, 0, 0],
+        // level 1: only roll tier 2s
+        [0, 0, 1, 0, 0, 0],
+      ],
       ['litwick', 'abra'],
       {
         litwick: { tier: 1, stage: 1, base: 'litwick' },
@@ -58,7 +56,7 @@ describe('shop rerolling', () => {
       } as any,
       { 1: 5, 2: 5, 3: 0, 4: 0, 5: 0 }
     );
-    expect(pool.reroll({ level: 1 } as Player)).toEqual([
+    expect(pool.reroll({ level: 0 } as Player)).toEqual([
       'litwick',
       'litwick',
       'litwick',
@@ -67,7 +65,7 @@ describe('shop rerolling', () => {
     ]);
     expect(pool.pools[1]).toHaveLength(0);
 
-    expect(pool.reroll({ level: 2 } as Player)).toEqual([
+    expect(pool.reroll({ level: 1 } as Player)).toEqual([
       'abra',
       'abra',
       'abra',
@@ -80,9 +78,7 @@ describe('shop rerolling', () => {
   test('should roll through different pokemon', () => {
     Math.random = alwaysLast;
     const pool = new ShopPool(
-      {
-        1: [0, 1, 0, 0, 0, 0],
-      },
+      [[0, 1, 0, 0, 0, 0]],
       ['litwick', 'fletchling'],
       {
         litwick: { tier: 1, stage: 1, base: 'litwick' },
@@ -90,7 +86,7 @@ describe('shop rerolling', () => {
       } as any,
       { 1: 3, 2: 0, 3: 0, 4: 0, 5: 0 }
     );
-    const rolls = pool.reroll({ level: 1 } as Player);
+    const rolls = pool.reroll({ level: 0 } as Player);
     expect(rolls).toEqual([
       // deterministic rng picks from the back
       'fletchling',
@@ -106,25 +102,21 @@ describe('shop rerolling', () => {
   test('should put stuff back in the pool when rerolling', () => {
     Math.random = alwaysFirst;
     const pool = new ShopPool(
-      {
-        1: [0, 1, 0, 0, 0, 0],
-      },
+      [[0, 1, 0, 0, 0, 0]],
       ['litwick'],
       { litwick: { tier: 1, stage: 1, base: 'litwick' } } as any,
       { 1: 10, 2: 0, 3: 0, 4: 0, 5: 0 }
     );
-    const rolls = pool.reroll({ level: 1 } as Player);
+    const rolls = pool.reroll({ level: 0 } as Player);
     expect(pool.pools[1]).toHaveLength(5);
-    pool.reroll({ level: 1 } as Player, rolls);
+    pool.reroll({ level: 0 } as Player, rolls);
     expect(pool.pools[1]).toHaveLength(5);
   });
 
   test('should put more back for higher stage pokemon', () => {
     Math.random = alwaysFirst;
     const pool = new ShopPool(
-      {
-        1: [0, 1, 0, 0, 0, 0],
-      },
+      [[0, 1, 0, 0, 0, 0]],
       ['litwick'],
       {
         litwick: { tier: 1, stage: 1 },
@@ -132,7 +124,7 @@ describe('shop rerolling', () => {
       } as any,
       { 1: 0, 2: 0, 3: 0, 4: 0, 5: 0 }
     );
-    const rolls = pool.reroll({ level: 1 } as Player, [
+    const rolls = pool.reroll({ level: 0 } as Player, [
       'chandelure',
       'chandelure',
       'chandelure',
@@ -155,9 +147,7 @@ describe('shop rerolling', () => {
   test('should fall back to alternative tiers if current is exhausted', () => {
     Math.random = customRng([0, 0.9999]);
     const pool = new ShopPool(
-      {
-        1: [0, 1, 1, 0, 0, 0],
-      },
+      [[0, 1, 1, 0, 0, 0]],
       ['litwick', 'abra'],
       {
         litwick: { tier: 1, stage: 1, base: 'litwick' },
@@ -165,7 +155,7 @@ describe('shop rerolling', () => {
       } as any,
       { 1: 3, 2: 3, 3: 0, 4: 0, 5: 0 }
     );
-    expect(pool.reroll({ level: 1 } as Player)).toEqual([
+    expect(pool.reroll({ level: 0 } as Player)).toEqual([
       // the rng alternates, but is used twice per pull (once for tier, once for pokemon)
       // so tier 1 ends up being all pulled first
       'litwick',
@@ -179,9 +169,7 @@ describe('shop rerolling', () => {
   test('should return empty slots if the entire shop is exhausted', () => {
     Math.random = alwaysFirst;
     const pool = new ShopPool(
-      {
-        1: [0, 1, 0, 0, 0, 0],
-      },
+      [[0, 1, 0, 0, 0, 0]],
       ['litwick'],
       {
         litwick: { tier: 1, stage: 1, base: 'litwick' },
@@ -189,7 +177,7 @@ describe('shop rerolling', () => {
       { 1: 2, 2: 0, 3: 0, 4: 0, 5: 0 }
     );
 
-    expect(pool.reroll({ level: 1 } as Player)).toEqual([
+    expect(pool.reroll({ level: 0 } as Player)).toEqual([
       'litwick',
       'litwick',
       ,
@@ -204,9 +192,7 @@ describe('shop rerolling', () => {
   test('should handle passed shops with deleted elements', () => {
     Math.random = alwaysFirst;
     const pool = new ShopPool(
-      {
-        1: [0, 1, 0, 0, 0, 0],
-      },
+      [[0, 1, 0, 0, 0, 0]],
       ['litwick'],
       {
         litwick: { tier: 1, stage: 1, base: 'litwick' },
@@ -223,7 +209,7 @@ describe('shop rerolling', () => {
     delete shop[1];
     delete shop[2];
 
-    expect(pool.reroll({ level: 1 } as Player, shop)).toEqual([
+    expect(pool.reroll({ level: 0 } as Player, shop)).toEqual([
       'litwick',
       'litwick',
       'litwick',

--- a/src/scenes/game/shop.helpers.ts
+++ b/src/scenes/game/shop.helpers.ts
@@ -28,9 +28,7 @@ export class ShopPool {
    *
    * eg. `[1, 2]` would give 50% chance of tier 1 and 50% of tier 2
    */
-  readonly rates: {
-    [level: string]: Pokemon['tier'][];
-  } = { 1: [], 2: [], 3: [], 4: [], 5: [], 6: [] };
+  readonly rates: Pokemon['tier'][][] = [];
 
   /**
    * Arrays containing all the Pokemon in a given tier pool.
@@ -45,18 +43,17 @@ export class ShopPool {
   } = { 1: [], 2: [], 3: [], 4: [], 5: [] };
 
   constructor(
-    rates: {
-      [k: string]: [number, number, number, number, number, number];
-    },
+    rates: [0, number, number, number, number, number][],
     // these are only used by tests to replace imports
     pokemonList: PokemonName[],
     private pokemonData: { [k in PokemonName]: Pokemon },
     poolSizes = SHOP_POOL_SIZES
   ) {
-    Object.keys(rates).forEach((level) => {
-      rates[level].forEach((rate, tier) => {
+    rates.forEach((shopOdds, /* index, which is */ level) => {
+      this.rates[level] = [];
+      shopOdds.forEach((chance, /* index, which is */ tier) => {
         // generate an array with that many elements
-        const arr = Array(rate).fill(tier);
+        const arr = Array(chance).fill(tier);
         // and append it to the existing rates
         this.rates[level].push(...arr);
       });

--- a/src/scenes/game/shop.helpers.ts
+++ b/src/scenes/game/shop.helpers.ts
@@ -1,13 +1,6 @@
 import { Pokemon, PokemonName } from '../../core/pokemon.model';
 import { Player } from '../../objects/player.object';
-
-const SHOP_POOL_SIZES = {
-  1: 27,
-  2: 24,
-  3: 21,
-  4: 18,
-  5: 15,
-};
+import { DEFAULT_SHOP_POOL } from './game.helpers';
 
 function getRandomIndex(array: unknown[]): number {
   return Math.floor(Math.random() * array.length);
@@ -47,7 +40,7 @@ export class ShopPool {
     // these are only used by tests to replace imports
     pokemonList: PokemonName[],
     private pokemonData: { [k in PokemonName]: Pokemon },
-    poolSizes = SHOP_POOL_SIZES
+    poolSizes = DEFAULT_SHOP_POOL
   ) {
     rates.forEach((shopOdds, /* index, which is */ level) => {
       this.rates[level] = [];

--- a/src/scenes/game/shop.scene.ts
+++ b/src/scenes/game/shop.scene.ts
@@ -164,7 +164,7 @@ export class ShopScene extends Phaser.Scene {
     this.playerGoldText.setText(`${this.player.gold}`);
 
     // update this here; it gets called on round start anyway so it should always be up-to-date
-    this.gameMode.shopRates[this.player.level].forEach((rate, i) => {
+    this.gameMode.levels[this.player.level].shopOdds.forEach((rate, i) => {
       if (i > 0) {
         this.oddsTexts[i].setText(`${rate}%`);
       }


### PR DESCRIPTION
This commit decouples level from board size, as I want to do more interesting things with leveling. It also sets up a basic framework (ie. the fields required) for manual level-ups.